### PR TITLE
chore: add github templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+* @grafana/partner-plugins

--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Report a bug you found when using this plugin
+labels: ['datasource/Sentry', 'type/bug']
+---
+
+<!--
+Please use this template to create your bug report. By providing as much info as possible you help us understand the issue, reproduce it and resolve it for you quicker. Therefore, take a couple of extra minutes to make sure you have provided all info needed.
+
+PROTIP: record your screen and attach it as a gif to showcase the issue.
+
+- Use query inspector to troubleshoot issues: https://bit.ly/2XNF6YS
+- How to record and attach gif: https://bit.ly/2Mi8T6K
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+<!--
+Example:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Screenshots**
+
+<!--
+If applicable, add screenshots to help explain your problem.
+-->
+
+**Anything else we need to know?**:
+
+**Environment**:
+
+- Grafana version:
+- Plugin version:
+- OS Grafana is installed on:
+- User OS & Browser:
+- Others:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Request
+    url: https://github.com/grafana/sentry-datasource/discussions/new
+    about: Discuss ideas for new features or changes
+  - name: Questions & Help
+    url: https://community.grafana.com
+    about: Please ask and answer questions here

--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,0 +1,34 @@
+[   
+    {
+      "type": "label",
+      "name": "datasource/Sentry",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/190"
+      }
+    },
+    {
+      "type": "label",
+      "name": "datasource/Sentry",
+      "action": "removeFromProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/190"
+      }
+    },
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    },
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "removeFromProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+<!-- To surface this PR in the changelog add the label: changelog -->
+<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
+<!-- Bad: fix state bug in hooks -->
+<!-- Good: Fix crash when switching from Query Builder -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,9 @@
+changelog:
+  categories:
+    - title: Copy the following lines for the CHANGELOG
+      labels:
+        - changelog
+    - title: Hidden
+      exclude:
+        labels:
+          - '*'

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -1,0 +1,23 @@
+name: Compatibility check
+on: [push, pull_request]
+
+jobs:
+  compatibilitycheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install dependencies
+        run: yarn install
+      - name: Build plugin
+        run: yarn build
+      - name: Compatibility check
+        uses: grafana/plugin-actions/is-compatible@v1
+        with:
+          module: './src/module.ts'
+          comment-pr: 'yes'
+          skip-comment-if-compatible: 'yes'
+          fail-if-incompatible: 'no'
+          targets: '@grafana/data,@grafana/ui,@grafana/runtime,@grafana/e2e-selectors'

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,0 +1,21 @@
+name: Run commands when issues are labeled
+on:
+  issues:
+    types: [labeled]
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_commands

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "e2e": "grafana-e2e run",
     "e2e:open": "grafana-e2e open",
     "e2e:update": "grafana-e2e run --update-screenshots",
-    "build": "grafana-toolkit plugin:build",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' grafana-toolkit plugin:build",
     "ci-build": "grafana-toolkit plugin:ci-build"
   },
   "dependencies": {


### PR DESCRIPTION
Using ADX's [templates](https://github.com/grafana/azure-data-explorer-datasource/tree/main/.github) as a basis for consistency.

Add basic templates and processes:
- CODEOWNERS
- Bugs
- FR (to Discussions)
- PR
- Automate CHANGELOG
- Levitate (as comments)
- Add to project board (for the new squad)

This does not include:
- Code coverage