### PR TITLE
Update state if there's a value for authToken

### DIFF
--- a/src/editors/SentryConfigEditor.tsx
+++ b/src/editors/SentryConfigEditor.tsx
@@ -87,12 +87,17 @@ export const SentryConfigEditor = (props: SentryConfigEditorProps) => {
           <>
             <Input
               type="password"
+              autoComplete="new-password"
               placeholder={ConfigEditorSelectors.SentrySettings.AuthToken.placeholder}
               aria-label={ConfigEditorSelectors.SentrySettings.AuthToken.ariaLabel}
               value={authToken}
               width={valueWidth * 2}
               onChange={(e) => setAuthToken(e.currentTarget.value)}
-              onBlur={() => onSecureOptionChange('authToken', authToken, true)}
+              onBlur={() => {
+                if (authToken !== '') {
+                  onSecureOptionChange('authToken', authToken, true);
+                }
+              }}
             ></Input>
           </>
         )}


### PR DESCRIPTION
Adding autoComplete `new-password` also prevents browser autofill from filling the password field with the grafana user password.

<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->
