### PR TITLE
Add initial feature tracking

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,6 +6,7 @@ import { SentryConfigEditor } from './editors/SentryConfigEditor';
 import { SentryQueryEditor } from './editors/SentryQueryEditor';
 import { SentryVariableEditor } from './editors/SentryVariableEditor';
 import type { SentryConfig, SentrySecureConfig, SentryQuery } from './types';
+import pluginJson from './plugin.json';
 
 export const plugin = new DataSourcePlugin<SentryDataSource, SentryQuery, SentryConfig, SentrySecureConfig>(SentryDataSource)
   .setConfigEditor(SentryConfigEditor)
@@ -24,6 +25,7 @@ getAppEvents().subscribe<DashboardLoadedEvent<SentryQuery>>(
     };
 
     trackSentryDashboardLoaded({
+      sentry_plugin_version: pluginJson.info.version,
       dashboardId: dashboardId,
       grafanaVersion: grafanaVersion,
       orgId: orgId,

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,10 @@ getAppEvents().subscribe<DashboardLoadedEvent<SentryQuery>>(
     const { payload } = props;
     const sentryQueries = payload.queries["grafana-sentry-datasource"];
 
+    if (!sentryQueries?.length) {
+      return;
+    };
+
     trackSentryDashboardLoaded({
       dashboardId: payload.dashboardId,
       grafanaVersion: payload.grafanaVersion,

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,8 +16,7 @@ export const plugin = new DataSourcePlugin<SentryDataSource, SentryQuery, Sentry
 // Track dashboard loads to RudderStack
 getAppEvents().subscribe<DashboardLoadedEvent<SentryQuery>>(
   DashboardLoadedEvent,
-  (props) => {
-    const { payload: { dashboardId, orgId, grafanaVersion, queries } } = props;
+  ({ payload: { dashboardId, orgId, grafanaVersion, queries } }) => {
     const sentryQueries = queries["grafana-sentry-datasource"];
 
     if (!sentryQueries?.length) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,17 +16,17 @@ export const plugin = new DataSourcePlugin<SentryDataSource, SentryQuery, Sentry
 getAppEvents().subscribe<DashboardLoadedEvent<SentryQuery>>(
   DashboardLoadedEvent,
   (props) => {
-    const { payload } = props;
-    const sentryQueries = payload.queries["grafana-sentry-datasource"];
+    const { payload: { dashboardId, orgId, grafanaVersion, queries } } = props;
+    const sentryQueries = queries["grafana-sentry-datasource"];
 
     if (!sentryQueries?.length) {
       return;
     };
 
     trackSentryDashboardLoaded({
-      dashboardId: payload.dashboardId,
-      grafanaVersion: payload.grafanaVersion,
-      orgId: payload.orgId,
+      dashboardId: dashboardId,
+      grafanaVersion: grafanaVersion,
+      orgId: orgId,
       ...analyzeQueries(sentryQueries),
     });
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,6 @@
-import { DataSourcePlugin } from '@grafana/data';
+import { DashboardLoadedEvent, DataSourcePlugin } from '@grafana/data';
+import { getAppEvents } from '@grafana/runtime';
+import { analyzeQueries, trackSentryDashboardLoaded } from 'tracking';
 import { SentryDataSource } from './datasource';
 import { SentryConfigEditor } from './editors/SentryConfigEditor';
 import { SentryQueryEditor } from './editors/SentryQueryEditor';
@@ -9,3 +11,19 @@ export const plugin = new DataSourcePlugin<SentryDataSource, SentryQuery, Sentry
   .setConfigEditor(SentryConfigEditor)
   .setQueryEditor(SentryQueryEditor)
   .setVariableQueryEditor(SentryVariableEditor);
+
+// Track dashboard loads to RudderStack
+getAppEvents().subscribe<DashboardLoadedEvent<SentryQuery>>(
+  DashboardLoadedEvent,
+  (props) => {
+    const { payload } = props;
+    const sentryQueries = payload.queries["grafana-sentry-datasource"];
+
+    trackSentryDashboardLoaded({
+      dashboardId: payload.dashboardId,
+      grafanaVersion: payload.grafanaVersion,
+      orgId: payload.orgId,
+      ...analyzeQueries(sentryQueries),
+    });
+  }
+);

--- a/src/tracking.test.ts
+++ b/src/tracking.test.ts
@@ -12,7 +12,7 @@ describe('analyzeQueries', () => {
         stats_query: 0,
         stats_query_outcome_filter: 0,
         stats_query_reason_filter: 0,
-        stats_query_groupby: 0 
+        stats_query_group_by: 0 
       },
     },
     {
@@ -24,7 +24,7 @@ describe('analyzeQueries', () => {
         stats_query: 0,
         stats_query_outcome_filter: 0,
         stats_query_reason_filter: 0,
-        stats_query_groupby: 0 
+        stats_query_group_by: 0 
       },
     },
     {
@@ -36,7 +36,7 @@ describe('analyzeQueries', () => {
         stats_query: 1,
         stats_query_outcome_filter: 0,
         stats_query_reason_filter: 0,
-        stats_query_groupby: 0 
+        stats_query_group_by: 0 
       },
     },
     {
@@ -48,7 +48,7 @@ describe('analyzeQueries', () => {
         stats_query: 1,
         stats_query_outcome_filter: 1,
         stats_query_reason_filter: 0,
-        stats_query_groupby: 0 
+        stats_query_group_by: 0 
       },
     },
     {
@@ -60,7 +60,7 @@ describe('analyzeQueries', () => {
         stats_query: 1,
         stats_query_outcome_filter: 0,
         stats_query_reason_filter: 1,
-        stats_query_groupby: 0 
+        stats_query_group_by: 0 
       },
     },
     {
@@ -72,7 +72,7 @@ describe('analyzeQueries', () => {
         stats_query: 1,
         stats_query_outcome_filter: 0,
         stats_query_reason_filter: 0,
-        stats_query_groupby: 1 
+        stats_query_group_by: 1 
       },
     },
     {
@@ -84,7 +84,7 @@ describe('analyzeQueries', () => {
         stats_query: 1,
         stats_query_outcome_filter: 1,
         stats_query_reason_filter: 1,
-        stats_query_groupby: 1 
+        stats_query_group_by: 1 
       },
     },
     {

--- a/src/tracking.test.ts
+++ b/src/tracking.test.ts
@@ -1,0 +1,123 @@
+import { analyzeQueries } from 'tracking';
+import { SentryQuery } from 'types';
+
+describe('analyzeQueries', () => {
+  [
+    {
+      description: 'should count 1 issues query',
+      queries: [{ queryType: "issues", environments: [] }],
+      expectedCounters: { 
+        issues_query: 1,
+        issues_query_environments: 0,
+        stats_query: 0,
+        stats_query_outcome_filter: 0,
+        stats_query_reason_filter: 0,
+        stats_query_groupby: 0 
+      },
+    },
+    {
+      description: 'should count 1 query environment (if set) in an issues query',
+      queries: [{ queryType: "issues", environments: [ "development" ] }],
+      expectedCounters: { 
+        issues_query: 1,
+        issues_query_environments: 1,
+        stats_query: 0,
+        stats_query_outcome_filter: 0,
+        stats_query_reason_filter: 0,
+        stats_query_groupby: 0 
+      },
+    },
+    {
+      description: 'should count 1 stats query',
+      queries: [{ queryType: "statsV2" }],
+      expectedCounters: { 
+        issues_query: 0,
+        issues_query_environments: 0,
+        stats_query: 1,
+        stats_query_outcome_filter: 0,
+        stats_query_reason_filter: 0,
+        stats_query_groupby: 0 
+      },
+    },
+    {
+      description: 'should count 1 outcome (if set) in a stats query',
+      queries: [{ queryType: "statsV2", statsOutcome: [ "filtered" ] }],
+      expectedCounters: { 
+        issues_query: 0,
+        issues_query_environments: 0,
+        stats_query: 1,
+        stats_query_outcome_filter: 1,
+        stats_query_reason_filter: 0,
+        stats_query_groupby: 0 
+      },
+    },
+    {
+      description: 'should count 1 reason (if set) in a stats query',
+      queries: [{ queryType: "statsV2", statsReason: [ "reason1" ] }],
+      expectedCounters: { 
+        issues_query: 0,
+        issues_query_environments: 0,
+        stats_query: 1,
+        stats_query_outcome_filter: 0,
+        stats_query_reason_filter: 1,
+        stats_query_groupby: 0 
+      },
+    },
+    {
+      description: 'should count 1 groupby (if set) in a stats query',
+      queries: [{ queryType: "statsV2", statsGroupBy: [ "category" ] }],
+      expectedCounters: { 
+        issues_query: 0,
+        issues_query_environments: 0,
+        stats_query: 1,
+        stats_query_outcome_filter: 0,
+        stats_query_reason_filter: 0,
+        stats_query_groupby: 1 
+      },
+    },
+    {
+      description: 'should count multiple optional filters (if set) in a stats query',
+      queries: [{ queryType: "statsV2", statsOutcome: [ "filtered" ], statsReason: [ "reason1" ], statsGroupBy: [ "category" ]}],
+      expectedCounters: { 
+        issues_query: 0,
+        issues_query_environments: 0,
+        stats_query: 1,
+        stats_query_outcome_filter: 1,
+        stats_query_reason_filter: 1,
+        stats_query_groupby: 1 
+      },
+    },
+    {
+      description: 'should count multiple queries',
+      queries: [{ queryType: "statsV2" }, { queryType: "issues" },],
+      expectedCounters: { 
+        issues_query: 1,
+        issues_query_environments: 0,
+        stats_query: 1,
+        stats_query_outcome_filter: 0,
+        stats_query_reason_filter: 0,
+        stats_query_groupby: 0 
+      },
+    },
+    {
+        description: 'should count multiple queries with filters',
+        queries: [{ queryType: "statsV2" , statsOutcome: [ "filtered" ], statsReason: [ "reason1" ], statsGroupBy: [ "category" ]}, { queryType: "issues", environments: [ "prod" ] },],
+        expectedCounters: { 
+          issues_query: 1,
+          issues_query_environments: 1,
+          stats_query: 1,
+          stats_query_outcome_filter: 1,
+          stats_query_reason_filter: 1,
+          stats_query_groupby: 1 
+        },
+      },
+  ].forEach((t) => {
+    it(t.description, () => {
+      expect(
+        analyzeQueries(
+          t.queries as SentryQuery[]
+        )
+      ).toMatchObject(t.expectedCounters);
+    });
+  });
+});

--- a/src/tracking.test.ts
+++ b/src/tracking.test.ts
@@ -96,7 +96,7 @@ describe('analyzeQueries', () => {
         stats_query: 1,
         stats_query_outcome_filter: 0,
         stats_query_reason_filter: 0,
-        stats_query_groupby: 0 
+        stats_query_group_by: 0 
       },
     },
     {
@@ -108,7 +108,7 @@ describe('analyzeQueries', () => {
           stats_query: 1,
           stats_query_outcome_filter: 1,
           stats_query_reason_filter: 1,
-          stats_query_groupby: 1 
+          stats_query_group_by: 1 
         },
       },
   ].forEach((t) => {

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -2,8 +2,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { SentryQuery } from 'types';
 
 export const trackSentryDashboardLoaded = (props: SentryDashboardLoadedProps) => {
-  console.log('trackSentryDashboardLoaded props', props);
-  reportInteraction('grafana_ds_clickhouse_dashboard_loaded', props);
+  reportInteraction('grafana_ds_sentry_dashboard_loaded', props);
 };
 
 export type SentryCounters = {
@@ -25,7 +24,7 @@ export const analyzeQueries = (queries: SentryQuery[]): SentryCounters => {
     stats_query: 0,
     stats_query_outcome_filter: 0,
     stats_query_reason_filter: 0,
-    stats_query_groupby: 0
+    stats_query_group_by: 0
   };
   
   queries.forEach((query) => {
@@ -45,7 +44,7 @@ export const analyzeQueries = (queries: SentryQuery[]): SentryCounters => {
           counters.stats_query_reason_filter++
         }
         if (query.statsGroupBy?.length > 0) {
-          counters.stats_query_groupby++
+          counters.stats_query_group_by++
         }
         break;
     }

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,0 +1,56 @@
+import { reportInteraction } from '@grafana/runtime';
+import { SentryQuery } from 'types';
+
+export const trackSentryDashboardLoaded = (props: SentryDashboardLoadedProps) => {
+  console.log('trackSentryDashboardLoaded props', props);
+  reportInteraction('grafana_ds_clickhouse_dashboard_loaded', props);
+};
+
+export type SentryCounters = {
+  issues_query: number,
+  stats_query: number,
+};
+
+export interface SentryDashboardLoadedProps extends SentryCounters {
+  dashboardId: string,
+  grafanaVersion?: string,
+  orgId?: number,
+  [key: string]: any;
+};
+
+export const analyzeQueries = (queries: SentryQuery[]): SentryCounters => {
+  const counters = {
+    issues_query: 0,
+    issues_query_environments: 0,
+    stats_query: 0,
+    stats_query_outcome_filter: 0,
+    stats_query_reason_filter: 0,
+    stats_query_groupby: 0
+  };
+  
+  queries.forEach((query) => {
+    switch (query.queryType) {
+      case "issues":
+        counters.issues_query++;
+        if (query.environments?.length > 0) {
+          counters.issues_query_environments++
+        }
+        break;
+      case "statsV2":
+        counters.stats_query++;
+        if (query.statsOutcome?.length > 0) {
+          counters.stats_query_outcome_filter++
+        }
+        if (query.statsReason?.length > 0) {
+          counters.stats_query_reason_filter++
+        }
+        if (query.statsGroupBy?.length > 0) {
+          counters.stats_query_groupby++
+        }
+        break;
+    }
+  });
+
+  return counters;
+};
+


### PR DESCRIPTION
**What happened**:

The goal of this task is to add feature tracking to Sentry so we can get more information on how much certain features are used. This PR adds initial tracking for the type of queries (issues vs stats) and if a issues query is used if an environment is set and if a stats query is chosen which optional filters are utilized (outcomes, reasons, groupby). With this information we can determine what how much certain features are used. If they are not, we can remove them from the code base, if they are we can improve its UX so they are easier to use.

**This is the list of things we can track so far**:

**Query editor**:
Format: Issues vs Stats query
Issues Query: If an environment (optional) is utitlized
Stats Query: If outcomes, reasons or groupby (all optional) are utilized

Closes #55  