### PR TITLE
Fix sentry version bug in feature tracking

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import { SentryConfigEditor } from './editors/SentryConfigEditor';
 import { SentryQueryEditor } from './editors/SentryQueryEditor';
 import { SentryVariableEditor } from './editors/SentryVariableEditor';
 import type { SentryConfig, SentrySecureConfig, SentryQuery } from './types';
-import pluginJson from './plugin.json';
+import sentryVersion from '../package.json';
 
 export const plugin = new DataSourcePlugin<SentryDataSource, SentryQuery, SentryConfig, SentrySecureConfig>(SentryDataSource)
   .setConfigEditor(SentryConfigEditor)
@@ -24,7 +24,7 @@ getAppEvents().subscribe<DashboardLoadedEvent<SentryQuery>>(
     };
 
     trackSentryDashboardLoaded({
-      sentry_plugin_version: pluginJson.info.version,
+      sentry_plugin_version: sentryVersion.version,
       dashboardId: dashboardId,
       grafanaVersion: grafanaVersion,
       orgId: orgId,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./.config/tsconfig.json"
+  "extends": "./.config/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
 }


### PR DESCRIPTION
This PR fixes a bug that was not properly tracking the Sentry version for feature tracking. The version is now pulled from `package.json`.