### PR TITLE
Find and replace existing comment when creating a PR build

### DIFF
--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.8.1
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: .nvmrc
 
       - name: Install Go environment
         uses: actions/setup-go@v4
@@ -82,13 +82,13 @@ jobs:
           COPY . /var/lib/grafana/plugins/${{ github.event.repository.name }}/" > Dockerfile
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
@@ -99,7 +99,27 @@ jobs:
     runs-on: ubuntu-latest
     needs: push_to_registry
     steps:
+      - name: Find previous comment (if any)
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: Use the following command to run this PR with Docker
+      - name: Update comment on PR
+        if: steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          issue-number: ${{ github.event.number }}
+          body: |
+            Use the following command to run this PR with Docker at http://localhost:3000:
+
+              ```
+              docker run --rm -p 3000:3000 grafana/plugin-builds:${{ github.event.pull_request.head.sha }}pre
+              ```
       - name: Add comment to PR
+        if: steps.fc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.number }}


### PR DESCRIPTION
This PR updates the comment posted by the GitHub Action that creates a Docker PR build, as we found that posting a new comment every time a new commit was pushed was too spammy.