### PR TITLE
Get authToken from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ datasources:
       authToken: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
+If the auth token is not set, the data source try to obtain it through the environment variable.
+
 ## Query the data source
 
 The query editor allows you to query Sentry, get sentry issues, events and stats and display them in Grafana dashboard panels. You can choose one of the following query types, to get the relevant data.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ datasources:
       authToken: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-If the auth token is not set, the data source try to obtain it through the environment variable.
+If the auth token is not set, the data source try to obtain it through the `SENTRY_AUTH_TOKEN` environment variable.
 
 ## Query the data source
 

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -19,9 +20,6 @@ func (sc *SentryConfig) Validate() error {
 	if sc.OrgSlug == "" {
 		return ErrorInvalidOrganizationSlug
 	}
-	if sc.authToken == "" {
-		return ErrorInvalidAuthToken
-	}
 	return nil
 }
 
@@ -38,9 +36,11 @@ func GetSettings(s backend.DataSourceInstanceSettings) (*SentryConfig, error) {
 	if config.OrgSlug == "" {
 		return nil, ErrorInvalidOrganizationSlug
 	}
-	if authToken, ok := s.DecryptedSecureJSONData["authToken"]; ok {
-		config.authToken = authToken
+	authToken, ok := s.DecryptedSecureJSONData["authToken"]
+	if !ok {
+		authToken = os.Getenv("SENTRY_AUTH_TOKEN")
 	}
+	config.authToken = authToken
 	if config.authToken == "" {
 		backend.Logger.Error(ErrorInvalidAuthToken.Error())
 		return nil, ErrorInvalidAuthToken

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -27,6 +27,11 @@ func TestGetSettings(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Equal(t, plugin.ErrorInvalidAuthToken, err)
 	})
+	t.Run("auth token should be set from env", func(t *testing.T) {
+		t.Setenv("SENTRY_AUTH_TOKEN", "bar")
+		_, err := plugin.GetSettings(backend.DataSourceInstanceSettings{JSONData: []byte(`{ "orgSlug": "foo" }`)})
+		assert.Nil(t, err)
+	})
 	t.Run("valid settings should correctly parsed and default url should apply", func(t *testing.T) {
 		settings, err := plugin.GetSettings(backend.DataSourceInstanceSettings{JSONData: []byte(`{ "orgSlug": "foo" }`), DecryptedSecureJSONData: map[string]string{"authToken": "bar"}})
 		assert.Nil(t, err)
@@ -53,11 +58,5 @@ func TestSentryConfig_validate(t *testing.T) {
 		err := sc.Validate()
 		assert.NotNil(t, err)
 		assert.Equal(t, plugin.ErrorInvalidOrganizationSlug, err)
-	})
-	t.Run("invalid password should throw error", func(t *testing.T) {
-		sc := &plugin.SentryConfig{URL: "https://foo.com", OrgSlug: "foo"}
-		err := sc.Validate()
-		assert.NotNil(t, err)
-		assert.Equal(t, plugin.ErrorInvalidAuthToken, err)
 	})
 }


### PR DESCRIPTION
This PR expands the method of obtaining the Sentry auth token.
As usual, if you provisioned by writing an authToken in secureJsonData, it will be used.
If you did not specify an authToken in secureJsonData, it will attempt to obtain the token from the `SENTRY_AUTH_TOKEN` environment variable.
With this PR, it will also be possible to achieve more secure management when managing Grafana's provisioning files with code.