### PR TITLE
Add getRequiredFields function

### DIFF
--- a/pkg/sentry/events.go
+++ b/pkg/sentry/events.go
@@ -7,20 +7,6 @@ import (
 	"time"
 )
 
-var reqFields = [...]string{
-	"id",
-	"title",
-	"project",
-	"project.id",
-	"release",
-	"count()",
-	"epm()",
-	"last_seen()",
-	"level",
-	"event.type",
-	"platform",
-}
-
 type SentryEvents struct {
 	Data []SentryEvent          `json:"data"`
 	Meta map[string]interface{} `json:"meta"`
@@ -51,6 +37,24 @@ type GetEventsInput struct {
 	Limit            int64
 }
 
+// getRequiredFields returns the list of fields that are required to be fetched
+// from the sentry API. This is used to build the query string.
+func getRequiredFields() []string {
+	return []string{
+		"id",
+		"title",
+		"project",
+		"project.id",
+		"release",
+		"count()",
+		"epm()",
+		"last_seen()",
+		"level",
+		"event.type",
+		"platform",
+	}
+}
+
 func (gei *GetEventsInput) ToQuery() string {
 	urlPath := fmt.Sprintf("/api/0/organizations/%s/events/?", gei.OrganizationSlug)
 	if gei.Limit < 1 || gei.Limit > 100 {
@@ -64,7 +68,7 @@ func (gei *GetEventsInput) ToQuery() string {
 		params.Set("sort", gei.Sort)
 	}
 	params.Set("per_page", strconv.FormatInt(gei.Limit, 10))
-	for _, field := range reqFields {
+	for _, field := range getRequiredFields() {
 		params.Add("field", field)
 	}
 	for _, projectId := range gei.ProjectIds {


### PR DESCRIPTION
This PR makes a small change to `events.go` to move `reqFields` from a global variable to being returned by a function. While we are not mutating this global variable currently, it's good to have this in case that changes in a future commit, as this will ensure that the values from `reqFields` are always constant across all instances.