### PR TITLE
Add support for Metrics queries

### DIFF
--- a/pkg/sentry/metrics.go
+++ b/pkg/sentry/metrics.go
@@ -1,0 +1,83 @@
+package sentry
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type MetricsResponse struct {
+	Start     time.Time   `json:"start"`
+	End       time.Time   `json:"end"`
+	Intervals []time.Time `json:"intervals"`
+	Groups    []struct {
+		By     map[string]interface{} `json:"by"`
+		Totals map[string]interface{} `json:"totals"`
+		Series map[string]interface{} `json:"series"`
+	} `json:"groups"`
+}
+
+type GetMetricsInput struct {
+	OrganizationSlug string
+	ProjectIds       []string
+	Environments     []string
+	From             time.Time
+	To               time.Time
+	Interval         time.Duration
+	Field            string
+	Query            string
+	GroupBy          string
+	Sort             string
+	Order            string
+	Limit            int64
+}
+
+func (args *GetMetricsInput) ToQuery() string {
+	urlPath := fmt.Sprintf("/api/0/organizations/%s/metrics/data/?", args.OrganizationSlug)
+	params := url.Values{}
+	params.Set("includeSeries", "1")
+	params.Set("start", args.From.Format("2006-01-02T15:04:05"))
+	params.Set("end", args.To.Format("2006-01-02T15:04:05"))
+	params.Set("interval", FormatSentryInterval(args.Interval))
+	if args.GroupBy != "" {
+		params.Add("groupBy", args.GroupBy)
+		if args.GroupBy != "session.status" {
+			if args.Limit < 1 || args.Limit > 10 {
+				args.Limit = 5
+			}
+			var orderModifier = "-"
+			if args.Order == "asc" {
+				orderModifier = ""
+			}
+			if args.Sort != "" {
+				params.Add("orderBy", orderModifier+args.Sort)
+			} else {
+				params.Add("orderBy", orderModifier+args.Field)
+			}
+			params.Set("per_page", strconv.FormatInt(args.Limit, 10))
+		}
+	} else {
+		params.Set("per_page", "1")
+	}
+	for _, projectId := range args.ProjectIds {
+		if projectId != "" {
+			params.Add("project", projectId)
+		}
+	}
+	for _, environment := range args.Environments {
+		params.Add("environment", environment)
+	}
+	params.Add("field", args.Field)
+	if args.Query != "" {
+		params.Add("query", args.Query)
+	}
+	return urlPath + params.Encode()
+}
+
+func (sc *SentryClient) GetMetrics(args GetMetricsInput) (MetricsResponse, string, error) {
+	var out MetricsResponse
+	executedQueryString := args.ToQuery()
+	err := sc.Fetch(executedQueryString, &out)
+	return out, sc.BaseURL + executedQueryString, err
+}

--- a/src/app/replace.ts
+++ b/src/app/replace.ts
@@ -40,6 +40,13 @@ export const applyTemplateVariables = (query: SentryQuery, scopedVars: ScopedVar
         projectIds: interpolateVariableArray(query.projectIds, scopedVars),
         environments: interpolateVariableArray(query.environments, scopedVars),
       };
+    case 'metrics':
+      return {
+        ...query,
+        metricsQuery: interpolateVariable(query.metricsQuery || '', scopedVars),
+        projectIds: interpolateVariableArray(query.projectIds, scopedVars),
+        environments: interpolateVariableArray(query.environments, scopedVars),
+      };
     case 'statsV2':
       return {
         ...query,

--- a/src/components/query-editor/MetricsEditor.spec.tsx
+++ b/src/components/query-editor/MetricsEditor.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MetricsEditor } from './MetricsEditor';
+import type { SentryMetricsQuery } from '../../types';
+
+describe('MetricsEditor', () => {
+  it('should render without error', () => {
+    const query = {
+      queryType: 'metrics',
+      projectIds: [],
+      environments: [],
+      metricsQuery: '',
+      metricsField: 'session.all',
+      refId: 'A',
+    } as SentryMetricsQuery;
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    const result = render(<MetricsEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />);
+    expect(result.container.firstChild).not.toBeNull();
+  });
+});

--- a/src/components/query-editor/MetricsEditor.tsx
+++ b/src/components/query-editor/MetricsEditor.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Input, QueryField, Select } from '@grafana/ui';
+import { selectors } from '../../selectors';
+import type {
+  SentryMetricsQuery,
+  SentryMetricsQueryField,
+  SentryMetricsQueryGroupBy,
+  SentryMetricsQuerySort,
+  SentryMetricsQueryOrder,
+} from '../../types';
+import { EditorField, EditorRow } from '@grafana/experimental';
+import {
+  SentryMetricsQueryFieldOptions,
+  SentryMetricsQueryGroupByOptions,
+  SentryMetricsQuerySortOptions,
+  SentryMetricsQueryOrderOptions,
+} from '../../constants';
+
+interface MetricsEditorProps {
+  query: SentryMetricsQuery;
+  onChange: (value: SentryMetricsQuery) => void;
+  onRunQuery: () => void;
+}
+
+export const MetricsEditor = ({ query, onChange, onRunQuery }: MetricsEditorProps) => {
+  const onMetricsFieldChange = (metricsField: SentryMetricsQueryField) => {
+    onChange({ ...query, metricsField });
+    onRunQuery();
+  };
+  const onMetricsQueryChange = (metricsQuery: string) => {
+    onChange({ ...query, metricsQuery });
+  };
+  const onMetricsGroupByChange = (metricsGroupBy: SentryMetricsQueryGroupBy) => {
+    onChange({ ...query, metricsGroupBy });
+    onRunQuery();
+  };
+  const onMetricsSortByChange = (metricsSort: SentryMetricsQuerySort) => {
+    onChange({ ...query, metricsSort });
+    onRunQuery();
+  };
+  const onMetricsSortOrderChange = (metricsOrder: SentryMetricsQueryOrder) => {
+    onChange({ ...query, metricsOrder });
+    onRunQuery();
+  };
+  const onMetricsLimitChange = (metricsLimit: number) => {
+    onChange({ ...query, metricsLimit });
+    onRunQuery();
+  };
+  return (
+    <>
+      <EditorRow>
+        <EditorField
+          tooltip={selectors.components.QueryEditor.Metrics.Field.tooltip}
+          label={selectors.components.QueryEditor.Metrics.Field.label}
+          width={50}
+        >
+          <Select
+            options={SentryMetricsQueryFieldOptions}
+            value={query.metricsField}
+            onChange={(e) => onMetricsFieldChange(e?.value!)}
+            className="inline-element"
+            placeholder={selectors.components.QueryEditor.Metrics.Field.placeholder}
+          />
+        </EditorField>
+      </EditorRow>
+      <EditorRow>
+        <EditorField
+          tooltip={selectors.components.QueryEditor.Metrics.Query.tooltip}
+          label={selectors.components.QueryEditor.Metrics.Query.label}
+          width={'100%'}
+        >
+          <QueryField
+            query={query.metricsQuery}
+            onChange={(val) => onMetricsQueryChange(val)}
+            onRunQuery={onRunQuery}
+            placeholder={selectors.components.QueryEditor.Metrics.Query.placeholder}
+            portalOrigin="Sentry"
+          />
+        </EditorField>
+      </EditorRow>
+      <EditorRow>
+        <EditorField
+          tooltip={selectors.components.QueryEditor.Metrics.GroupBy.tooltip}
+          label={selectors.components.QueryEditor.Metrics.GroupBy.label}
+          width={50}
+        >
+          <Select
+            options={SentryMetricsQueryGroupByOptions}
+            value={query.metricsGroupBy}
+            onChange={(e) => onMetricsGroupByChange(e?.value!)}
+            className="inline-element"
+            placeholder={selectors.components.QueryEditor.Metrics.GroupBy.placeholder}
+            isClearable={true}
+          />
+        </EditorField>
+      </EditorRow>
+      {query.metricsGroupBy && query.metricsGroupBy !== 'session.status' && (
+        <EditorRow>
+          <EditorField
+            tooltip={selectors.components.QueryEditor.Metrics.Sort.tooltip}
+            label={selectors.components.QueryEditor.Metrics.Sort.label}
+            width={30}
+          >
+            <Select
+              options={SentryMetricsQuerySortOptions}
+              value={query.metricsSort}
+              onChange={(e) => onMetricsSortByChange(e?.value!)}
+              className="inline-element"
+              placeholder={selectors.components.QueryEditor.Metrics.Sort.placeholder}
+              isClearable={true}
+            />
+          </EditorField>
+          <EditorField
+            tooltip={selectors.components.QueryEditor.Metrics.Order.tooltip}
+            label={selectors.components.QueryEditor.Metrics.Order.label}
+            width={30}
+          >
+            <Select
+              options={SentryMetricsQueryOrderOptions}
+              value={query.metricsOrder}
+              onChange={(e) => onMetricsSortOrderChange(e?.value!)}
+              className="inline-element"
+              placeholder={selectors.components.QueryEditor.Metrics.Order.placeholder}
+              isClearable={true}
+            />
+          </EditorField>
+          <EditorField
+            tooltip={selectors.components.QueryEditor.Metrics.Limit.tooltip}
+            label={selectors.components.QueryEditor.Metrics.Limit.label}
+          >
+            <Input
+              value={query.metricsLimit}
+              type="number"
+              onChange={(e) => onMetricsLimitChange(e.currentTarget.valueAsNumber)}
+              onBlur={onRunQuery}
+              width={32}
+              className="inline-element"
+              placeholder={selectors.components.QueryEditor.Metrics.Limit.placeholder}
+            />
+          </EditorField>
+        </EditorRow>
+      )}
+    </>
+  );
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,18 +2,23 @@ import type { SelectableValue } from '@grafana/data';
 import type {
   QueryType,
   SentryIssueSort,
-  SentryEventSort,  
+  SentryEventSort,
   SentryStatsV2QueryField,
   SentryStatsV2QueryGroupBy,
   SentryStatsV2QueryCategory,
   SentryStatsV2QueryOutcome,
+  SentryMetricsQueryField,
+  SentryMetricsQueryGroupBy,
+  SentryMetricsQueryOrder,
+  SentryMetricsQuerySort,
 } from './types';
 
 export const QueryTypeOptions: Array<SelectableValue<QueryType>> = [
   { value: 'issues', label: 'Issues' },
-  { value: 'events', label: 'Events' },  
+  { value: 'events', label: 'Events' },
   { value: 'statsV2', label: 'Stats' },
   { value: 'eventsStats', label: 'Events Stats' },
+  { value: 'metrics', label: 'Metrics' },
 ];
 export const SentryIssueSortOptions: Array<SelectableValue<SentryIssueSort>> = [
   // { value: 'inbox', label: 'Date Added' },
@@ -30,6 +35,39 @@ export const SentryEventSortOptions: Array<SelectableValue<SentryEventSort>> = [
   { value: 'failure_rate()', label: 'Failure rate' },
   { value: 'level', label: 'Level' },
 ];
+export const SentryMetricsQueryFieldOptions: Array<SelectableValue<SentryMetricsQueryField>> = [
+  { value: 'session.anr_rate', label: 'session.anr_rate' },
+  { value: 'session.abnormal', label: 'session.abnormal' },
+  { value: 'session.abnormal_user', label: 'session.abnormal_user' },
+  { value: 'session.crashed', label: 'session.crashed' },
+  { value: 'session.crashed_user', label: 'session.crashed_user' },
+  { value: 'session.errored', label: 'session.errored' },
+  { value: 'session.errored_user', label: 'session.errored_user' },
+  { value: 'session.healthy', label: 'session.healthy' },
+  { value: 'session.healthy_user', label: 'session.healthy_user' },
+  { value: 'count_unique(sentry.sessions.user)', label: 'count_unique(sentry.sessions.user)' },
+  { value: 'session.crash_free_rate', label: 'session.crash_free_rate' },
+  { value: 'session.crash_free_user_rate', label: 'session.crash_free_user_rate' },
+  { value: 'session.crash_rate', label: 'session.crash_rate' },
+  { value: 'session.crash_user_rate', label: 'session.crash_user_rate' },
+  { value: 'session.foreground_anr_rate', label: 'session.foreground_anr_rate' },
+  { value: 'session.all', label: 'session.all' },
+];
+export const SentryMetricsQuerySortOptions: Array<SelectableValue<SentryMetricsQuerySort>> = [
+  ...SentryMetricsQueryFieldOptions,
+  { value: 'release', label: 'release' },
+];
+export const SentryMetricsQueryOrderOptions: Array<SelectableValue<SentryMetricsQueryOrder>> = [
+  { value: 'desc', label: 'High to low' },
+  { value: 'asc', label: 'Low to high' },
+];
+export const SentryMetricsQueryGroupByOptions: Array<SelectableValue<SentryMetricsQueryGroupBy>> = [
+  { value: 'environment', label: 'environment' },
+  { value: 'project', label: 'project' },
+  { value: 'session.status', label: 'session.status' },
+  { value: 'release', label: 'release' },
+];
+
 export const SentryStatsV2QueryFieldOptions: Array<SelectableValue<SentryStatsV2QueryField>> = [
   { value: 'sum(quantity)', label: 'sum(quantity)' },
   { value: 'sum(times_seen)', label: 'sum(times_seen)' },

--- a/src/editors/SentryQueryEditor.tsx
+++ b/src/editors/SentryQueryEditor.tsx
@@ -11,6 +11,7 @@ import type { SentryConfig, SentryQuery } from './../types';
 import './../styles/editor.scss';
 import { EditorRows } from '@grafana/experimental';
 import { EventsStatsEditor } from 'components/query-editor/EventsStatsEditor';
+import { MetricsEditor } from 'components/query-editor/MetricsEditor';
 
 type SentryQueryEditorProps = {} & QueryEditorProps<SentryDataSource, SentryQuery, SentryConfig>;
 
@@ -33,6 +34,9 @@ export const SentryQueryEditor = (props: SentryQueryEditorProps) => {
       {query.queryType === 'events' ? <EventsEditor query={query} onChange={onChange} onRunQuery={onRunQuery} /> : null}
       {query.queryType === 'eventsStats' ? (
         <EventsStatsEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />
+      ) : null}
+      {query.queryType === 'metrics' ? (
+        <MetricsEditor query={query} onChange={onChange} onRunQuery={onRunQuery} />
       ) : null}
     </EditorRows>
   );

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -112,6 +112,38 @@ export const Components = {
         placeholder: '10',
       },
     },
+    Metrics: {
+      Field: {
+        label: 'Field',
+        tooltip: 'metrics field',
+        placeholder: 'Required. Select one or more fields to see the metric',
+      },
+      Query: {
+        label: 'Query',
+        tooltip: 'Sentry query to filter the results',
+        placeholder: 'Enter a Sentry query (run with Shift+Enter)',
+      },
+      GroupBy: {
+        label: 'Group By',
+        tooltip: 'group by',
+        placeholder: 'Optional. Select the option to group the results',
+      },
+      Sort: {
+        label: 'Sort By',
+        tooltip: 'Sort results',
+        placeholder: 'Optional',
+      },
+      Order: {
+        label: 'Order',
+        tooltip: 'Sort order',
+        placeholder: 'Optional',
+      },
+      Limit: {
+        label: 'Limit',
+        tooltip: 'Number of results (10 max)',
+        placeholder: '5',
+      },
+    },
     StatsV2: {
       Field: {
         label: 'Field',

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export interface SentrySecureConfig {
 //#endregion
 
 //#region Query
-export type QueryType = 'issues' | 'events' | 'statsV2' | 'eventsStats';
+export type QueryType = 'issues' | 'events' | 'statsV2' | 'eventsStats' | 'metrics';
 export type SentryQueryBase<T extends QueryType> = { queryType: T } & DataQuery;
 export type SentryIssuesQuery = {
   projectIds: string[];
@@ -77,6 +77,36 @@ export type SentryEventsStatsQuery = {
   eventsStatsLimit?: number;
   eventsStatsGroups: string[];
 } & SentryQueryBase<'eventsStats'>;
+export type SentryMetricsQueryField =
+  | 'session.anr_rate'
+  | 'session.abnormal'
+  | 'session.abnormal_user'
+  | 'session.crashed'
+  | 'session.crashed_user'
+  | 'session.errored'
+  | 'session.errored_user'
+  | 'session.healthy'
+  | 'session.healthy_user'
+  | 'count_unique(sentry.sessions.user)'
+  | 'session.crash_free_rate'
+  | 'session.crash_free_user_rate'
+  | 'session.crash_rate'
+  | 'session.crash_user_rate'
+  | 'session.foreground_anr_rate'
+  | 'session.all';
+export type SentryMetricsQueryGroupBy = 'environment' | 'project' | 'session.status' | 'release';
+export type SentryMetricsQuerySort = SentryMetricsQueryField | 'release';
+export type SentryMetricsQueryOrder = 'asc' | 'desc';
+export type SentryMetricsQuery = {
+  projectIds: string[];
+  environments: string[];
+  metricsField: SentryMetricsQueryField;
+  metricsQuery: string;
+  metricsGroupBy?: SentryMetricsQueryGroupBy;
+  metricsLimit?: number;
+  metricsSort?: SentryMetricsQuerySort;
+  metricsOrder?: SentryMetricsQueryOrder;
+} & SentryQueryBase<'metrics'>;
 export type SentryStatsV2QueryField = 'sum(quantity)' | 'sum(times_seen)';
 export type SentryStatsV2QueryGroupBy = 'outcome' | 'reason' | 'category';
 export type SentryStatsV2QueryCategory = 'transaction' | 'error' | 'attachment' | 'default' | 'session' | 'security';
@@ -90,7 +120,12 @@ export type SentryStatsV2Query = {
   statsReason: string[];
   statsInterval: string;
 } & SentryQueryBase<'statsV2'>;
-export type SentryQuery = SentryIssuesQuery | SentryEventsQuery | SentryEventsStatsQuery | SentryStatsV2Query;
+export type SentryQuery =
+  | SentryIssuesQuery
+  | SentryEventsQuery
+  | SentryEventsStatsQuery
+  | SentryMetricsQuery
+  | SentryStatsV2Query;
 //#endregion
 
 //#region Variable Query


### PR DESCRIPTION
This PR adds support for metrics queries used to graph stuff like crash rate and release adoption. 

I've tried to follow feedback and style guide from previous PR. One piece I'm less satisfied with is the loop to extract labels for grouped queries, if there is a more elegant solution, please advise 🙏  

![Screenshot 2024-05-15 at 14 21 19](https://github.com/grafana/sentry-datasource/assets/378279/b0017b42-314a-4336-ad6f-c51cb820e240)
![Screenshot 2024-05-15 at 13 55 43](https://github.com/grafana/sentry-datasource/assets/378279/cee408f3-99c5-4e34-b17e-b74b81b07646)
