### PR TITLE
Fix Event data link in ID field

### DIFF
--- a/pkg/framer/framer.go
+++ b/pkg/framer/framer.go
@@ -82,7 +82,7 @@ func UpdateFrameMeta(frame *data.Frame, executedQueryString string, query query.
 				Links: []data.DataLink{
 					{
 						Title:       "Open in Sentry",
-						URL:         fmt.Sprintf("https://%s.sentry.io/discover/${__data.fields[\"Project\"]}:${__data.fields[\"ID\"]}/", orgSlug),
+						URL:         fmt.Sprintf("%s/organizations/%s/discover/${__data.fields[\"Project\"]}:${__data.fields[\"ID\"]}/", baseURL, orgSlug),
 						TargetBlank: true,
 					},
 				},


### PR DESCRIPTION
## Fix Event data link in ID field
- The **Events** query type visualization table has an incorrect data link within the `ID` field.
- This fix takes into consideration the user provided `baseURL`, replacing `sentry.io`.

<p align="center">
  <img src="https://github.com/grafana/sentry-datasource/assets/47757441/eba87857-658c-4025-8c19-4e752e3934b5" width="700">
</p>
