### PR TITLE
Use `datasource.Manage` to initialise the datasource

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -5,14 +5,16 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
 	"github.com/grafana/sentry-datasource/pkg/plugin"
 )
 
 func main() {
 	backend.SetupPluginEnvironment(plugin.PluginID)
-	err := datasource.Serve(plugin.NewDatasource())
-	if err != nil {
-		backend.Logger.Error("error loading plugin", "pluginId", plugin.PluginID)
+
+	if err := datasource.Manage("grafana-sentry-datasource", plugin.NewDatasource, datasource.ManageOpts{}); err != nil {
+		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}
 }

--- a/pkg/plugin/handlers_healthcheck.go
+++ b/pkg/plugin/handlers_healthcheck.go
@@ -5,22 +5,11 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/sentry-datasource/pkg/sentry"
 )
 
+// CheckHealth is a callback that is called when Grafana requests a health check for the datasource during setup.
 func (ds *SentryDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	dsi, err := ds.getDatasourceInstance(ctx, req.PluginContext)
-	if err != nil {
-		return &backend.CheckHealthResult{
-			Status:  backend.HealthStatusError,
-			Message: err.Error(),
-		}, nil
-	}
-	return CheckHealth(dsi.sentryClient)
-}
-
-func CheckHealth(sentryClient sentry.SentryClient) (*backend.CheckHealthResult, error) {
-	projects, err := sentryClient.GetProjects(sentryClient.OrgSlug, false)
+	projects, err := ds.client.GetProjects(ds.client.OrgSlug, false)
 	if err != nil {
 		errorMessage := err.Error()
 		return &backend.CheckHealthResult{
@@ -28,6 +17,7 @@ func CheckHealth(sentryClient sentry.SentryClient) (*backend.CheckHealthResult, 
 			Message: errorMessage,
 		}, nil
 	}
+
 	return &backend.CheckHealthResult{
 		Status:  backend.HealthStatusOk,
 		Message: fmt.Sprintf("%s. %v projects found.", SuccessfulHealthCheckMessage, len(projects)),

--- a/pkg/plugin/handlers_healthcheck_test.go
+++ b/pkg/plugin/handlers_healthcheck_test.go
@@ -1,6 +1,7 @@
 package plugin_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -8,31 +9,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_checkHealth(t *testing.T) {
+func Test_CheckHealth(t *testing.T) {
 	t.Run("invalid auth token should throw error", func(t *testing.T) {
-		sc := NewFakeClient(fakeDoer{AuthToken: "incorrect-token"})
-		hc, err := plugin.CheckHealth(*sc)
+		ds := plugin.NewDatasourceInstance(NewFakeClient(fakeDoer{AuthToken: "incorrect-token"}))
+		ctx := context.TODO()
+		req := &backend.CheckHealthRequest{}
+		hc, err := ds.CheckHealth(ctx, req)
 		assert.Nil(t, err)
 		assert.Equal(t, backend.HealthStatusError, hc.Status)
 		assert.Equal(t, "401 Unauthorized", hc.Message)
 	})
 	t.Run("valid auth token should not throw error", func(t *testing.T) {
-		sc := NewFakeClient(fakeDoer{Body: "[]"})
-		hc, err := plugin.CheckHealth(*sc)
+		ds := plugin.NewDatasourceInstance(NewFakeClient(fakeDoer{Body: "[]"}))
+		ctx := context.TODO()
+		req := &backend.CheckHealthRequest{}
+		hc, err := ds.CheckHealth(ctx, req)
 		assert.Nil(t, err)
 		assert.Equal(t, backend.HealthStatusOk, hc.Status)
 		assert.Equal(t, "plugin health check successful. 0 projects found.", hc.Message)
 	})
 	t.Run("should return organizations length", func(t *testing.T) {
-		sc := NewFakeClient(fakeDoer{Body: "[{},{}]"})
-		hc, err := plugin.CheckHealth(*sc)
+		ds := plugin.NewDatasourceInstance(NewFakeClient(fakeDoer{Body: "[{},{}]"}))
+		ctx := context.TODO()
+		req := &backend.CheckHealthRequest{}
+		hc, err := ds.CheckHealth(ctx, req)
 		assert.Nil(t, err)
 		assert.Equal(t, backend.HealthStatusOk, hc.Status)
 		assert.Equal(t, "plugin health check successful. 2 projects found.", hc.Message)
 	})
 	t.Run("invalid response should throw error", func(t *testing.T) {
-		sc := NewFakeClient(fakeDoer{Body: "{}"})
-		hc, err := plugin.CheckHealth(*sc)
+		ds := plugin.NewDatasourceInstance(NewFakeClient(fakeDoer{Body: "{}"}))
+		ctx := context.TODO()
+		req := &backend.CheckHealthRequest{}
+		hc, err := ds.CheckHealth(ctx, req)
 		assert.Nil(t, err)
 		assert.Equal(t, backend.HealthStatusError, hc.Status)
 		assert.Equal(t, "json: cannot unmarshal object into Go value of type []sentry.SentryProject", hc.Message)

--- a/pkg/plugin/handlers_query.go
+++ b/pkg/plugin/handlers_query.go
@@ -46,15 +46,12 @@ func GetQuery(query backend.DataQuery) (SentryQuery, error) {
 
 func (ds *SentryDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	response := backend.NewQueryDataResponse()
-	dsi, err := ds.getDatasourceInstance(ctx, req.PluginContext)
-	if err != nil {
-		response.Responses["error"] = backend.DataResponse{Error: err}
-		return response, nil
-	}
+
 	for _, q := range req.Queries {
-		res := QueryData(ctx, req.PluginContext, q, dsi.sentryClient)
+		res := QueryData(ctx, req.PluginContext, q, ds.client)
 		response.Responses[q.RefID] = res
 	}
+
 	return response, nil
 }
 


### PR DESCRIPTION
This PR updates the datasource to use the `datasource.Manage` method from the SDK to initialise the datasource, instead of the deprecated `datasource.Serve`, along with other associated fixes.