### PR TITLE
errorsource updates

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -148,7 +148,7 @@ func HandleStatsV2(client sentry.SentryClient, query query.SentryQuery, backendQ
 	})
 	if err != nil {
 		// errorsource set by Sentry client
-		return errors.GetErrorResponse(response, executedQueryString, err)
+		return errors.GetErrorResponse(response, executedQueryString, errorsource.DownstreamError(err, false))
 	}
 	frame, err := framer.ConvertStatsV2ResponseToFrame(framer.GetFrameName("Stats", backendQuery.RefID), stats)
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -116,6 +116,7 @@ func createResponse(backendQuery backend.DataQuery, client sentry.SentryClient) 
 		return handlers.HandleStatsV2(client, query, backendQuery, response)
 	default:
 		response.Error = errors.ErrorUnknownQueryType
+		response.ErrorSource = backend.ErrorSourceDownstream
 	}
 
 	return response


### PR DESCRIPTION
- Unknown query type errors are now marked as `downstream`
- Wrap errors from the `StatsV2` handler as `downstream` if they don't already have a source