### PR TITLE
Make substatus data available

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -28,6 +28,8 @@
     "oblador",
     "peterhellberg",
     "proxying",
+    "Substatus",
+    "substatus",
     "testdata",
     "testid",
     "typecheck",

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -26,7 +26,7 @@ func TestSentryDatasource_Issues(t *testing.T) {
 		assert.Nil(t, res.Responses["A"].Error)
 		require.Equal(t, 1, len(res.Responses["A"].Frames))
 		assert.Equal(t, "Issues (A)", res.Responses["A"].Frames[0].Name)
-		require.Equal(t, 32, len(res.Responses["A"].Frames[0].Fields))
+		require.Equal(t, 33, len(res.Responses["A"].Frames[0].Fields))
 		require.Equal(t, 3, res.Responses["A"].Frames[0].Fields[0].Len())
 	})
 }

--- a/pkg/sentry/issues.go
+++ b/pkg/sentry/issues.go
@@ -14,6 +14,7 @@ type SentryIssue struct {
 	Count       string    `json:"count"`
 	UserCount   int64     `json:"userCount"`
 	Status      string    `json:"status"`
+	Substatus   string    `json:"substatus"`
 	Level       string    `json:"level"`
 	Type        string    `json:"type"`
 	Platform    string    `json:"platform"`


### PR DESCRIPTION
Makes the `substatus` field available. This allows distinguishing between new, ongoing and regressed issues.