### PR TITLE
Update config to support fork tests

### DIFF
--- a/e2e/smoke/configEditor.spec.ts
+++ b/e2e/smoke/configEditor.spec.ts
@@ -7,8 +7,8 @@ test.describe('Create Sentry datasource - smoke', () => {
       type: 'grafana-sentry-datasource',
     });
 
-    await expect(page.getByTestId(Components.ConfigEditor.SentrySettings.URL.placeholder)).toBeVisible();
-    await expect(page.getByTestId(Components.ConfigEditor.SentrySettings.OrgSlug.placeholder)).toBeVisible();
-    await expect(page.getByTestId(Components.ConfigEditor.SentrySettings.AuthToken.placeholder)).toBeVisible();
+    await expect(page.getByPlaceholder(Components.ConfigEditor.SentrySettings.URL.placeholder)).toBeVisible();
+    await expect(page.getByPlaceholder(Components.ConfigEditor.SentrySettings.OrgSlug.placeholder)).toBeVisible();
+    await expect(page.getByPlaceholder(Components.ConfigEditor.SentrySettings.AuthToken.placeholder)).toBeVisible();
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import type { PluginOptions } from '@grafana/plugin-e2e';
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 
 export default defineConfig<PluginOptions>({
-  testDir: './e2e/frontend',
+  testDir: './e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -23,7 +23,7 @@ export default defineConfig<PluginOptions>({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    video: 'on'
+    video: 'on',
   },
 
   /* Configure projects for major browsers */
@@ -42,6 +42,6 @@ export default defineConfig<PluginOptions>({
         storageState: 'playwright/.auth/admin.json',
       },
       dependencies: ['auth'],
-    }
+    },
   ],
 });


### PR DESCRIPTION
Update Playwright config to run any tests in the `e2e` folder.

Update the config smoke test to be valid for the Sentry config editor.