### PR TITLE
Fix querying for events and issues

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -15,9 +15,13 @@ func HandleIssues(client sentry.SentryClient, query query.SentryQuery, backendQu
 	if client.OrgSlug == "" {
 		return errors.GetErrorResponse(response, "", errorsource.DownstreamError(errors.ErrorInvalidOrganizationSlug, false))
 	}
+	projectId := ""
+	if len(query.ProjectIds) > 0 {
+		projectId = query.ProjectIds[0]
+	}
 	issues, executedQueryString, err := client.GetIssues(sentry.GetIssuesInput{
 		OrganizationSlug: client.OrgSlug,
-		ProjectIds:       query.ProjectIds,
+		ProjectId:        projectId,
 		Environments:     query.Environments,
 		Query:            query.IssuesQuery,
 		Sort:             query.IssuesSort,
@@ -43,9 +47,13 @@ func HandleEvents(client sentry.SentryClient, query query.SentryQuery, backendQu
 	if client.OrgSlug == "" {
 		return errors.GetErrorResponse(response, "", errorsource.DownstreamError(errors.ErrorInvalidOrganizationSlug, false))
 	}
+	projectId := ""
+	if len(query.ProjectIds) > 0 {
+		projectId = query.ProjectIds[0]
+	}
 	events, executedQueryString, err := client.GetEvents(sentry.GetEventsInput{
 		OrganizationSlug: client.OrgSlug,
-		ProjectIds:       query.ProjectIds,
+		ProjectId:        projectId,
 		Environments:     query.Environments,
 		Query:            query.EventsQuery,
 		Fields:           query.EventsFields,

--- a/pkg/sentry/events.go
+++ b/pkg/sentry/events.go
@@ -9,7 +9,7 @@ import (
 
 type GetEventsInput struct {
 	OrganizationSlug string
-	ProjectIds       []string
+	ProjectId        string
 	Environments     []string
 	Fields           []string
 	Query            string
@@ -20,7 +20,7 @@ type GetEventsInput struct {
 }
 
 func (gei *GetEventsInput) ToQuery() string {
-	urlPath := fmt.Sprintf("/api/0/organizations/%s/events/?", gei.OrganizationSlug)
+	urlPath := fmt.Sprintf("/api/0/projects/%s/%s/events/?", gei.OrganizationSlug, gei.ProjectId)
 	if gei.Limit < 1 || gei.Limit > 100 {
 		gei.Limit = 100
 	}
@@ -35,20 +35,40 @@ func (gei *GetEventsInput) ToQuery() string {
 	for _, field := range gei.Fields {
 		params.Add("field", field)
 	}
-	for _, projectId := range gei.ProjectIds {
-		params.Add("project", projectId)
-	}
 	for _, environment := range gei.Environments {
 		params.Add("environment", environment)
 	}
 	return urlPath + params.Encode()
 }
 
-func (sc *SentryClient) GetEvents(gei GetEventsInput) ([]map[string]interface{}, string, error) {
-	var out struct {
-		Data []map[string]interface{} `json:"data"`
-	}
+type EventResult struct {
+	Id          string            `json:"id"`
+	Type        string            `json:"event.type"`
+	GroupId     string            `json:"groupID"`
+	EventId     string            `json:"eventID"`
+	ProjectId   string            `json:"projectID"`
+	Message     string            `json:"message"`
+	Title       string            `json:"title"`
+	User        User              `json:"user"`
+	Tags        []Tag             `json:"tags"`
+	Platform    string            `json:"platform"`
+	DateCreated string            `json:"dateCreated"`
+	Metadata    map[string]string `json:"metadata"`
+}
+
+type User struct {
+	Username string `json:"username"`
+}
+
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Query string `json:"query"`
+}
+
+func (sc *SentryClient) GetEvents(gei GetEventsInput) ([]EventResult, string, error) {
+	var eventResults []EventResult
 	executedQueryString := gei.ToQuery()
-	err := sc.Fetch(executedQueryString, &out)
-	return out.Data, sc.BaseURL + executedQueryString, err
+	err := sc.Fetch(executedQueryString, &eventResults)
+	return eventResults, sc.BaseURL + executedQueryString, err
 }

--- a/pkg/sentry/issues.go
+++ b/pkg/sentry/issues.go
@@ -61,7 +61,7 @@ type SentryIssue struct {
 
 type GetIssuesInput struct {
 	OrganizationSlug string
-	ProjectIds       []string
+	ProjectId        string
 	Environments     []string
 	Query            string
 	From             time.Time
@@ -71,7 +71,7 @@ type GetIssuesInput struct {
 }
 
 func (gii *GetIssuesInput) ToQuery() string {
-	urlPath := fmt.Sprintf("/api/0/organizations/%s/issues/?", gii.OrganizationSlug)
+	urlPath := fmt.Sprintf("/api/0/projects/%s/%s/issues/?", gii.OrganizationSlug, gii.ProjectId)
 	if gii.Limit < 1 || gii.Limit > 10000 {
 		gii.Limit = 10000
 	}
@@ -83,9 +83,6 @@ func (gii *GetIssuesInput) ToQuery() string {
 		params.Set("sort", gii.Sort)
 	}
 	params.Set("limit", strconv.FormatInt(gii.Limit, 10))
-	for _, projectId := range gii.ProjectIds {
-		params.Add("project", projectId)
-	}
 	for _, environment := range gii.Environments {
 		params.Add("environment", environment)
 	}


### PR DESCRIPTION
The query url for events and issues lived under `/api/0/organizations`:

```
/api/0/organizations/$ORG_SLUG/events/?$QUERY_PARAMS
/api/0/organizations/$ORG_SLUG/issues/?$QUERY_PARAMS
```

These endpoint don't return results anymore, and don't exist in the
Sentry API documentation.

New endpoints that do return resutls exist for events and issues:

```
/api/0/projects/$ORG_SLUG/$PROJECT_ID/events/?$QUERY_PARAMS
/api/0/projects/$ORG_SLUG/$PROJECT_ID/issues/?$QUERY_PARAMS
```

This PR updates queries to use the new API endpoints.

Also, event decoding expected an object with a key `data`, and a list of
event objects as the value. The new API endpoint returns a list of events,
so this PR updates the decoding to expect that.

This PR is enough to make queries run, and render them, but it's not
enough. Followup PRs are required to fix the interface, because it
currently assumes an organization context, with a list of projects.

