### PR TITLE
Bump @grafana/plugin-e2e from 1.19.1 to 1.19.2 in the dependencies group

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.24.3",
     "@grafana/e2e-selectors": "11.6.0",
     "@grafana/eslint-config": "^8.0.0",
-    "@grafana/plugin-e2e": "^1.19.1",
+    "@grafana/plugin-e2e": "^1.19.2",
     "@grafana/tsconfig": "^2.0.0",
     "@playwright/test": "^1.51.1",
     "@swc/core": "^1.3.90",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,10 +1250,20 @@
     uplot "1.6.31"
     xss "^1.0.14"
 
-"@grafana/e2e-selectors@11.6.0", "@grafana/e2e-selectors@^11.6.0-229231":
+"@grafana/e2e-selectors@11.6.0":
   version "11.6.0"
   resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-11.6.0.tgz#50ac0cecf09ea680b700bc3a9d3109acb554630e"
   integrity sha512-3nJBRYjOTIi9WbclY6tp0NOj6KUpN7mJW4xBV6nYvqK5X48PWQ8u7SUG+nZyTSYQ/9AY88V2EMZmkCMNfE99hA==
+  dependencies:
+    "@grafana/tsconfig" "^2.0.0"
+    semver "^7.7.0"
+    tslib "2.8.1"
+    typescript "5.7.3"
+
+"@grafana/e2e-selectors@^12.0.0-234029":
+  version "12.0.0-234204"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-12.0.0-234204.tgz#7f6f1c204f34e076f83b111467ee4005a6480f08"
+  integrity sha512-6kZDxPCXvHTab7UZqTC80mLKcKP9t88SBci+4BcTAuuvavlC6NRbT44+WPGfzHUsghEXy1rFLwQgg3iwVLynVQ==
   dependencies:
     "@grafana/tsconfig" "^2.0.0"
     semver "^7.7.0"
@@ -1282,12 +1292,12 @@
     ua-parser-js "^1.0.32"
     web-vitals "^4.0.1"
 
-"@grafana/plugin-e2e@^1.19.1":
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-1.19.1.tgz#58fbc43f957b2307365f0ec8491b38205dba4dd5"
-  integrity sha512-2xEZfUS3zg5CR+l5yj8nAfPn5oyQTF4UDxEjkQdp4qly4kulxq/bklRChxjD6pmfp5E1rmtxI/EQT8PaHVK9+g==
+"@grafana/plugin-e2e@^1.19.2":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-1.19.2.tgz#655928fe552ecffb26d87431071a3dc891d79330"
+  integrity sha512-2mFcUqmr8MGJXI03K1d2nz/KswB2lmIfd/bOHq8559UJX+jk0th3ypnWUF70KuNtZBElQyiiLlDmP/o8VuHK0A==
   dependencies:
-    "@grafana/e2e-selectors" "^11.6.0-229231"
+    "@grafana/e2e-selectors" "^12.0.0-234029"
     semver "^7.5.4"
     uuid "^11.0.2"
     yaml "^2.3.4"


### PR DESCRIPTION
Creating this to see if it will make Drone run.