### PR TITLE
Secure GHA Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@main
+        uses: grafana/plugin-actions/e2e-version@bf335ac99375f0ba8828497abdf1a22897b5d888
         with:
           version-resolver-type: version-support-policy
 

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,6 +1,6 @@
 name: Dependabot reviewer
 
-on: pull_request_target
+on: pull_request
 
 permissions:
   pull-requests: write

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build plugin
         run: yarn build
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@v1
+        uses: grafana/plugin-actions/is-compatible@f567fc6454619e6c8dbc2f91692197457c10a02b
         with:
           module: './src/module.ts'
           comment-pr: 'yes'


### PR DESCRIPTION
Fixing remaining `high` issues reported by zizmor.

- Replace `pull_request_target` with `pull_request` in the dependabot-reviewer workflow
- Pin third-party GitHub actions to specific SHAs