### PR TITLE
Bump @grafana/plugin-e2e from 2.0.2 to 2.0.3 in the dependencies group

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/core": "^7.27.3",
     "@grafana/e2e-selectors": "12.0.1",
     "@grafana/eslint-config": "^8.0.0",
-    "@grafana/plugin-e2e": "^2.0.2",
+    "@grafana/plugin-e2e": "^2.0.3",
     "@grafana/tsconfig": "^2.0.0",
     "@playwright/test": "1.50.1",
     "@swc/core": "^1.3.90",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1397,10 +1397,10 @@
     tslib "2.8.1"
     typescript "5.7.3"
 
-"@grafana/e2e-selectors@^12.1.0-242212":
-  version "12.1.0-246121"
-  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-12.1.0-246121.tgz#bac07e84337674d062a79cb9f3a066b7629cb731"
-  integrity sha512-vh1rVuQz9zsViRA18win8DM7xyVAV3hKBZYorR6EXb0D6rJ+cv3Sq4GT2hemrgjgHIN5iMUMQhB0c1LGvomXSA==
+"@grafana/e2e-selectors@^12.1.0-246483":
+  version "12.1.0-247353"
+  resolved "https://registry.yarnpkg.com/@grafana/e2e-selectors/-/e2e-selectors-12.1.0-247353.tgz#8484ebcea5677d6fefee355606c0aad61c402fcb"
+  integrity sha512-Ll3hfYXoDiRMwTBCiZOtd3QfAsf9tF4UVpc7Y0EltzZRgQzGmSfAiThvdKekJeFObl+Ychpp3WODSbBMplkyOA==
   dependencies:
     "@grafana/tsconfig" "^2.0.0"
     semver "^7.7.0"
@@ -1429,12 +1429,12 @@
     ua-parser-js "^1.0.32"
     web-vitals "^4.0.1"
 
-"@grafana/plugin-e2e@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-2.0.2.tgz#b9dafe7bb4653269ff16360c1d9d81862487f6ca"
-  integrity sha512-aLVs4VgZgi5pq2YynirrZQ8p8W7XZsliw5Dyk9Hdb7DfcIMYU7g1/rERYuwzsdtH1BVvEp5JwmEE16EPcbf80w==
+"@grafana/plugin-e2e@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@grafana/plugin-e2e/-/plugin-e2e-2.0.3.tgz#98325e460648bf8cfb44fd16f40de8fd3d6aaa7d"
+  integrity sha512-EXQXu0lGbFZHTbPogB8Pivsmn3sXx67AbzOBEsQvDKFnsuagmDGIr9XT51HFZnDCb/Ympga5bWGsiZz2uskNkg==
   dependencies:
-    "@grafana/e2e-selectors" "^12.1.0-242212"
+    "@grafana/e2e-selectors" "^12.1.0-246483"
     semver "^7.5.4"
     uuid "^11.0.2"
     yaml "^2.3.4"
@@ -10288,12 +10288,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.3.4:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.1.tgz#44a247d1b88523855679ac7fa7cda6ed7e135cf6"
-  integrity sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==
-
-yaml@^2.8.0:
+yaml@^2.3.4, yaml@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
   integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==


### PR DESCRIPTION
Bumps the dependencies group with 1 update: [@grafana/plugin-e2e](https://github.com/grafana/plugin-tools/tree/HEAD/packages/plugin-e2e).

this PR exists only to bump Drone.