### PR TITLE
Deploy to Grafana Cloud only from publish workflow

### DIFF
--- a/.github/workflows/publish-to-cloud.yml
+++ b/.github/workflows/publish-to-cloud.yml
@@ -1,5 +1,5 @@
-name: Plugins - CD
-run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+name: Deploy to Grafana Cloud
+run-name: Deploy ${{ inputs.branch }} to Grafana Cloud ${{ inputs.environment }} by @${{ github.actor }}
 
 on:
   workflow_dispatch:
@@ -34,8 +34,7 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      scopes: universal
+      scopes: grafana_cloud
       go-version: '1.24'
       golangci-lint-version: '2.1.6'
       run-playwright: false
-


### PR DESCRIPTION
This PR adds `scopes: grafana_cloud` to our publish workflow. The build
artifacts will only be available in Grafana Cloud, enabling us to test
the release there before releasing for OSS and on-prem.

The release docs here have been updated to include a section for Sentry
when this PR is merged. tl;dr: an extra command will need to be run to
publish a version to on-prem and OSS:

```
$ SENTRY_VERSION=2.2.1
$ gcom /plugins/grafana-sentry-datasource/versions/$SENTRY_VERSION -XPOST -d scopes=universal
```


