### PR TITLE
Add TLS certificate verification skip option

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -53,6 +53,15 @@ func NewDatasource(ctx context.Context, s backend.DataSourceInstanceSettings) (i
 		return nil, err
 	}
 
+	// configure TLS skip verify if enabled
+	if settings.TLSSkipVerify {
+		if opt.TLS == nil {
+			opt.TLS = &httpclient.TLSOptions{}
+		}
+		opt.TLS.InsecureSkipVerify = true
+		backend.Logger.Warn("TLS certificate verification is disabled - this is insecure and should only be used with self-signed certificates")
+	}
+
 	hc, err := httpclient.New(opt)
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -9,9 +9,10 @@ import (
 )
 
 type SentryConfig struct {
-	URL       string `json:"url"`
-	OrgSlug   string `json:"orgSlug"`
-	authToken string `json:"-"`
+	URL           string `json:"url"`
+	OrgSlug       string `json:"orgSlug"`
+	TLSSkipVerify bool   `json:"tlsSkipVerify"`
+	authToken     string `json:"-"`
 }
 
 func (sc *SentryConfig) Validate() error {

--- a/src/components/config-editor/AdditionalSettings.tsx
+++ b/src/components/config-editor/AdditionalSettings.tsx
@@ -14,26 +14,41 @@ interface AdditionalSettingsProps {
 }
 
 export function AdditionalSettings({ jsonData, onOptionChange }: AdditionalSettingsProps) {
-  return config.secureSocksDSProxyEnabled && isVersionGtOrEq(config.buildInfo.version, '10.0.0') ? (
+  const shouldShowSection = config.secureSocksDSProxyEnabled && isVersionGtOrEq(config.buildInfo.version, '10.0.0');
+  const isInitiallyOpen = jsonData.enableSecureSocksProxy || jsonData.tlsSkipVerify;
+
+  return (
     <>
       <Divider />
       <ConfigSection
         title="Additional settings"
-        description="Additional settings are optional settings that can be configured for more control over your data source. This includes enabling the secure socks proxy."
+        description="Additional settings are optional settings that can be configured for more control over your data source."
         isCollapsible
-        isInitiallyOpen={jsonData.enableSecureSocksProxy}
+        isInitiallyOpen={isInitiallyOpen}
       >
+        {shouldShowSection && (
+          <Field
+            label={Components.ConfigEditor.SecureSocksProxy.label}
+            description={Components.ConfigEditor.SecureSocksProxy.tooltip}
+          >
+            <Switch
+              className="gf-form"
+              value={jsonData.enableSecureSocksProxy || false}
+              onChange={(e) => onOptionChange('enableSecureSocksProxy', e.currentTarget.checked)}
+            />
+          </Field>
+        )}
         <Field
-          label={Components.ConfigEditor.SecureSocksProxy.label}
-          description={Components.ConfigEditor.SecureSocksProxy.tooltip}
+          label={Components.ConfigEditor.TLSSkipVerify.label}
+          description={Components.ConfigEditor.TLSSkipVerify.tooltip}
         >
           <Switch
             className="gf-form"
-            value={jsonData.enableSecureSocksProxy || false}
-            onChange={(e) => onOptionChange('enableSecureSocksProxy', e.currentTarget.checked)}
+            value={jsonData.tlsSkipVerify || false}
+            onChange={(e) => onOptionChange('tlsSkipVerify', e.currentTarget.checked)}
           />
         </Field>
       </ConfigSection>
     </>
-  ) : null;
+  );
 }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -32,6 +32,10 @@ export const Components = {
       label: 'Enable Secure Socks Proxy',
       tooltip: 'Enable proxying the datasource connection through the secure socks proxy to a different network.',
     },
+    TLSSkipVerify: {
+      label: 'Skip TLS Verify',
+      tooltip: 'Skip TLS certificate verification. Use this option for self-hosted Sentry instances with self-signed certificates.',
+    },
   },
   QueryEditor: {
     QueryType: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface SentryConfig extends DataSourceJsonData {
   url: string;
   orgSlug: string;
   enableSecureSocksProxy?: boolean;
+  tlsSkipVerify?: boolean;
 }
 export interface SentrySecureConfig {
   authToken: string;


### PR DESCRIPTION
Adds a new "Skip TLS Verify" checkbox to datasource configuration that allows users to disable TLS certificate verification for self-hosted Sentry instances with self-signed certificates.

  Frontend changes:
  - Add tlsSkipVerify field to SentryConfig interface (src/types.ts:58)
  - Add TLSSkipVerify checkbox component with label and tooltip (src/components/config-editor/AdditionalSettings.tsx:41-48)
  - Update AdditionalSettings to always show section if either option is enabled (src/components/config-editor/AdditionalSettings.tsx:18)
  - Add TLSSkipVerify selector labels (src/selectors.ts:35-38)

  Backend changes:
  - Add TLSSkipVerify bool field to SentryConfig struct (pkg/plugin/settings.go:14)
  - Configure HTTP client with InsecureSkipVerify when enabled (pkg/plugin/plugin.go:56-62)
  - Add warning log when TLS verification is disabled (pkg/plugin/plugin.go:62)