### PR TITLE
Update docs publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,12 +24,8 @@ permissions: {}
 
 jobs:
   cd:
-    strategy:
-      fail-fast: false
-      matrix:
-        environment: [dev, ops, prod]
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: write
       id-token: write
@@ -37,7 +33,7 @@ jobs:
       pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
-      environment: ${{ matrix.environment }}
+      environment: 'prod'
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
       run-playwright: false

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v10.1.0
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
use `prod` environment for cd workflow

Docs-only publishing fails when the Plugins - CD workflow runs against the dev and ops matrix jobs because docs publishing is only allowed when targeting prod.

Set the CD workflow environment to prod and remove the matrix. Since prod targets all environments by default, this still publishes to dev, ops, and prod without needing separate jobs for each environment [cd.yml](https://github.com/grafana/plugin-ci-workflows/blob/62d4239b0781e59478a07866e0c721388e3c0d53/.github/workflows/cd.yml#L316).

Also update plugin-ci-workflows to [v10.1.0](https://github.com/grafana/plugin-ci-workflows/releases/tag/ci-cd-workflows%2Fv10.1.0) so docs publishing uses the latest workflow behavior.