### PR TITLE
Exclude SentryToken detector from TruffleHog in CD workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,3 +38,4 @@ jobs:
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
       run-playwright: false
       github-draft-release: false
+      trufflehog-exclude-detectors: SentryToken


### PR DESCRIPTION
## Summary

The `Deploy to Grafana Cloud` workflow fails in the `CI / Test and build plugin` job (exit code 183) because TruffleHog's `SentryToken` detector flags a false positive: the signed plugin `MANIFEST.txt` (generated by `@grafana/sign-plugin`) contains SHA256 hashes adjacent to paths that include "sentry". This blocks both plugin and docs publishing — which is why the docs from #705 never went live.

This scopes a single exclusion to the `SentryToken` detector so all other detectors (AWS, GitHub tokens, etc.) stay active.

This is the same fix as #717, re-authored under a CLA-signed account so the `license/cla` check passes (the Copilot-authored #717 was blocked indefinitely on CLA).

## Changes

- `.github/workflows/publish.yml`: add `trufflehog-exclude-detectors: SentryToken` to the `cd` job's `with` block.

## Test plan

- [ ] Re-run **Deploy to Grafana Cloud** (with `docs-only: true`) after merge and confirm the `Test and build plugin` job passes and docs publish.


Made with [Cursor](https://cursor.com)