### PR TITLE
Respect Grafana query interval in Spans Stats requests

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -150,6 +150,7 @@ func HandleSpansStats(client sentry.SentryClient, query query.SentryQuery, backe
 		Sort:             query.EventsStatsSort,
 		Limit:            query.EventsStatsLimit,
 		Interval:         backendQuery.Interval,
+		MaxDataPoints:    backendQuery.MaxDataPoints,
 		From:             backendQuery.TimeRange.From,
 		To:               backendQuery.TimeRange.To,
 	})

--- a/pkg/sentry/events_stats.go
+++ b/pkg/sentry/events_stats.go
@@ -2,7 +2,6 @@ package sentry
 
 import (
 	"fmt"
-	"math"
 	"net/url"
 	"strconv"
 	"time"
@@ -22,16 +21,6 @@ type GetEventsStatsInput struct {
 	Sort             string
 	Interval         time.Duration
 	Limit            int64
-}
-
-func FormatSentryInterval(interval time.Duration) string {
-	if interval.Hours() > 2 {
-		return fmt.Sprintf("%dh", int(math.Round(interval.Hours())))
-	}
-	if interval.Minutes() > 2 {
-		return fmt.Sprintf("%dm", int(math.Round(interval.Minutes())))
-	}
-	return fmt.Sprintf("%ds", int(math.Round(interval.Seconds())))
 }
 
 func (gei *GetEventsStatsInput) ToQuery() string {

--- a/pkg/sentry/interval.go
+++ b/pkg/sentry/interval.go
@@ -11,15 +11,22 @@ var allowedSpansStatsIntervals = []int64{
 	15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 14400, 21600, 43200, 86400,
 }
 
-const spansStatsTargetBuckets = 500
+const defaultSpansStatsDataPoints int64 = 800
 
-func snapSpansStatsInterval(interval time.Duration, timeRange time.Duration) string {
+func init() {
 	slices.Sort(allowedSpansStatsIntervals)
+}
 
+func snapSpansStatsInterval(interval time.Duration, timeRange time.Duration, maxDataPoints int64) string {
 	minAllowed := time.Duration(allowedSpansStatsIntervals[0]) * time.Second
 	intervalSuggestion := interval
+
+	resolvedMaxDataPoints := defaultSpansStatsDataPoints
+	if maxDataPoints > 0 {
+		resolvedMaxDataPoints = maxDataPoints
+	}
 	if interval < minAllowed || interval > timeRange {
-		intervalSuggestion = timeRange / spansStatsTargetBuckets
+		intervalSuggestion = timeRange / time.Duration(resolvedMaxDataPoints)
 	}
 	nearest := minAllowed
 	for _, seconds := range allowedSpansStatsIntervals {

--- a/pkg/sentry/interval.go
+++ b/pkg/sentry/interval.go
@@ -1,0 +1,51 @@
+package sentry
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"time"
+)
+
+var allowedSpansStatsIntervals = []int64{
+	15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 14400, 21600, 43200, 86400,
+}
+
+const spansStatsTargetBuckets = 500
+
+func snapSpansStatsInterval(interval time.Duration, timeRange time.Duration) string {
+	slices.Sort(allowedSpansStatsIntervals)
+
+	minAllowed := time.Duration(allowedSpansStatsIntervals[0]) * time.Second
+	intervalSuggestion := interval
+	if interval < minAllowed || interval > timeRange {
+		intervalSuggestion = timeRange / spansStatsTargetBuckets
+	}
+	nearest := minAllowed
+	for _, seconds := range allowedSpansStatsIntervals {
+		valid := time.Duration(seconds) * time.Second
+		if (intervalSuggestion - valid).Abs() < (intervalSuggestion - nearest).Abs() {
+			nearest = valid
+		}
+	}
+	if nearest > timeRange {
+		for i := len(allowedSpansStatsIntervals) - 1; i >= 0; i-- {
+			valid := time.Duration(allowedSpansStatsIntervals[i]) * time.Second
+			if valid <= timeRange {
+				nearest = valid
+				break
+			}
+		}
+	}
+	return FormatSentryInterval(nearest)
+}
+
+func FormatSentryInterval(interval time.Duration) string {
+	if interval.Hours() > 2 {
+		return fmt.Sprintf("%dh", int(math.Round(interval.Hours())))
+	}
+	if interval.Minutes() > 2 {
+		return fmt.Sprintf("%dm", int(math.Round(interval.Minutes())))
+	}
+	return fmt.Sprintf("%ds", int(math.Round(interval.Seconds())))
+}

--- a/pkg/sentry/interval_test.go
+++ b/pkg/sentry/interval_test.go
@@ -1,0 +1,45 @@
+package sentry
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestSnapSpansStatsInterval(t *testing.T) {
+	tests := []struct {
+		name      string
+		interval  time.Duration
+		timeRange time.Duration
+		want      string
+	}{
+		{"below minimum falls back to range-derived interval", 14 * time.Second, time.Hour, "15s"},
+		{"larger than range falls back to range-derived interval", 2 * time.Hour, time.Hour, "15s"},
+		{"zero interval derives from range", 0, 4 * time.Hour, "30s"},
+
+		{"minimum allowed is kept", 15 * time.Second, time.Hour, "15s"},
+		{"snaps to nearest allowed value", 32 * time.Second, time.Hour, "30s"},
+		{"snaps up to nearest allowed value", 28 * time.Second, time.Hour, "30s"},
+		{"equidistant value snaps down", 45 * time.Second, time.Hour, "30s"},
+		{"above maximum snaps to one day", 25 * time.Hour, 30 * 24 * time.Hour, "24h"},
+
+		{"rounding up past the range snaps down to largest fitting", 50 * time.Second, 55 * time.Second, "30s"},
+		{"range below minimum still sends the minimum", 10 * time.Second, 10 * time.Second, "15s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := snapSpansStatsInterval(tt.interval, tt.timeRange)
+			if got != tt.want {
+				t.Errorf("snapSpansStatsInterval(%v, %v) = %q, want %q", tt.interval, tt.timeRange, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapSpansStatsIntervalUnsortedList(t *testing.T) {
+	slices.Reverse(allowedSpansStatsIntervals)
+	snapSpansStatsInterval(32*time.Second, time.Hour)
+	if !slices.IsSorted(allowedSpansStatsIntervals) {
+		t.Error("allowedSpansStatsIntervals should be sorted after the call")
+	}
+}

--- a/pkg/sentry/interval_test.go
+++ b/pkg/sentry/interval_test.go
@@ -8,38 +8,40 @@ import (
 
 func TestSnapSpansStatsInterval(t *testing.T) {
 	tests := []struct {
-		name      string
-		interval  time.Duration
-		timeRange time.Duration
-		want      string
+		name          string
+		interval      time.Duration
+		timeRange     time.Duration
+		maxDataPoints int64
+		want          string
 	}{
-		{"below minimum falls back to range-derived interval", 14 * time.Second, time.Hour, "15s"},
-		{"larger than range falls back to range-derived interval", 2 * time.Hour, time.Hour, "15s"},
-		{"zero interval derives from range", 0, 4 * time.Hour, "30s"},
+		{"below minimum falls back to range-derived interval", 14 * time.Second, time.Hour, 0, "15s"},
+		{"larger than range falls back to range-derived interval", 2 * time.Hour, time.Hour, 0, "15s"},
+		{"zero interval derives from range", 0, 4 * time.Hour, 0, "30s"},
 
-		{"minimum allowed is kept", 15 * time.Second, time.Hour, "15s"},
-		{"snaps to nearest allowed value", 32 * time.Second, time.Hour, "30s"},
-		{"snaps up to nearest allowed value", 28 * time.Second, time.Hour, "30s"},
-		{"equidistant value snaps down", 45 * time.Second, time.Hour, "30s"},
-		{"above maximum snaps to one day", 25 * time.Hour, 30 * 24 * time.Hour, "24h"},
+		{"minimum allowed is kept", 15 * time.Second, time.Hour, 0, "15s"},
+		{"snaps to nearest allowed value", 32 * time.Second, time.Hour, 0, "30s"},
+		{"snaps up to nearest allowed value", 28 * time.Second, time.Hour, 0, "30s"},
+		{"equidistant value snaps down", 45 * time.Second, time.Hour, 0, "30s"},
+		{"above maximum snaps to one day", 25 * time.Hour, 30 * 24 * time.Hour, 0, "24h"},
 
-		{"rounding up past the range snaps down to largest fitting", 50 * time.Second, 55 * time.Second, "30s"},
-		{"range below minimum still sends the minimum", 10 * time.Second, 10 * time.Second, "15s"},
+		{"rounding up past the range snaps down to largest fitting", 50 * time.Second, 55 * time.Second, 0, "30s"},
+		{"range below minimum still sends the minimum", 10 * time.Second, 10 * time.Second, 0, "15s"},
+
+		{"zero maxDataPoints falls back to the default bucket count", 0, 1000 * time.Second, 0, "15s"},
+		{"custom maxDataPoints changes the derived interval", 0, 1000 * time.Second, 10, "120s"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := snapSpansStatsInterval(tt.interval, tt.timeRange)
+			got := snapSpansStatsInterval(tt.interval, tt.timeRange, tt.maxDataPoints)
 			if got != tt.want {
-				t.Errorf("snapSpansStatsInterval(%v, %v) = %q, want %q", tt.interval, tt.timeRange, got, tt.want)
+				t.Errorf("snapSpansStatsInterval(%v, %v, %v) = %q, want %q", tt.interval, tt.timeRange, tt.maxDataPoints, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestSnapSpansStatsIntervalUnsortedList(t *testing.T) {
-	slices.Reverse(allowedSpansStatsIntervals)
-	snapSpansStatsInterval(32*time.Second, time.Hour)
+func TestAllowedSpansStatsIntervalsSorted(t *testing.T) {
 	if !slices.IsSorted(allowedSpansStatsIntervals) {
-		t.Error("allowedSpansStatsIntervals should be sorted after the call")
+		t.Error("allowedSpansStatsIntervals should be sorted by init()")
 	}
 }

--- a/pkg/sentry/interval_test.go
+++ b/pkg/sentry/interval_test.go
@@ -16,7 +16,7 @@ func TestSnapSpansStatsInterval(t *testing.T) {
 	}{
 		{"below minimum falls back to range-derived interval", 14 * time.Second, time.Hour, 0, "15s"},
 		{"larger than range falls back to range-derived interval", 2 * time.Hour, time.Hour, 0, "15s"},
-		{"zero interval derives from range", 0, 4 * time.Hour, 0, "30s"},
+		{"zero interval derives from range", 0, 4 * time.Hour, 0, "15s"},
 
 		{"minimum allowed is kept", 15 * time.Second, time.Hour, 0, "15s"},
 		{"snaps to nearest allowed value", 32 * time.Second, time.Hour, 0, "30s"},

--- a/pkg/sentry/spans_stats.go
+++ b/pkg/sentry/spans_stats.go
@@ -20,6 +20,7 @@ type GetSpansStatsInput struct {
 	To               time.Time
 	Sort             string
 	Interval         time.Duration
+	MaxDataPoints    int64
 	Limit            int64
 }
 
@@ -33,7 +34,7 @@ func (gei *GetSpansStatsInput) ToQuery() string {
 	params.Set("query", gei.Query)
 	params.Set("start", gei.From.Format("2006-01-02T15:04:05Z07:00"))
 	params.Set("end", gei.To.Format("2006-01-02T15:04:05Z07:00"))
-	params.Set("interval", snapSpansStatsInterval(gei.Interval, gei.To.Sub(gei.From)))
+	params.Set("interval", snapSpansStatsInterval(gei.Interval, gei.To.Sub(gei.From), gei.MaxDataPoints))
 	params.Set("partial", "1")
 	params.Set("excludeOther", "0")
 	params.Set("sampling", "NORMAL")

--- a/pkg/sentry/spans_stats.go
+++ b/pkg/sentry/spans_stats.go
@@ -9,29 +9,6 @@ import (
 
 type SentrySpansStats = map[string]interface{}
 
-var allowedSpansStatsIntervals = []int64{15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 14400, 21600, 43200, 86400}
-
-func (gei *GetSpansStatsInput) snapInterval() bool {
-	min := time.Duration(allowedSpansStatsIntervals[0]) * time.Second
-	max := time.Duration(allowedSpansStatsIntervals[len(allowedSpansStatsIntervals)-1]) * time.Second
-
-	if gei.Interval < min || gei.Interval > max {
-		return false
-	}
-	nearest := min
-	for _, seconds := range allowedSpansStatsIntervals {
-		valid := time.Duration(seconds) * time.Second
-		if (gei.Interval - valid).Abs() < (gei.Interval - nearest).Abs() {
-			nearest = valid
-		}
-	}
-	if nearest > gei.To.Sub(gei.From) {
-		return false
-	}
-	gei.Interval = nearest
-	return true
-}
-
 type GetSpansStatsInput struct {
 	OrganizationSlug string
 	ProjectIds       []string
@@ -56,9 +33,7 @@ func (gei *GetSpansStatsInput) ToQuery() string {
 	params.Set("query", gei.Query)
 	params.Set("start", gei.From.Format("2006-01-02T15:04:05Z07:00"))
 	params.Set("end", gei.To.Format("2006-01-02T15:04:05Z07:00"))
-	if gei.snapInterval() {
-		params.Set("interval", FormatSentryInterval(gei.Interval))
-	}
+	params.Set("interval", snapSpansStatsInterval(gei.Interval, gei.To.Sub(gei.From)))
 	params.Set("partial", "1")
 	params.Set("excludeOther", "0")
 	params.Set("sampling", "NORMAL")

--- a/pkg/sentry/spans_stats.go
+++ b/pkg/sentry/spans_stats.go
@@ -9,6 +9,29 @@ import (
 
 type SentrySpansStats = map[string]interface{}
 
+var allowedSpansStatsIntervals = []int64{15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 14400, 21600, 43200, 86400}
+
+func (gei *GetSpansStatsInput) snapInterval() bool {
+	min := time.Duration(allowedSpansStatsIntervals[0]) * time.Second
+	max := time.Duration(allowedSpansStatsIntervals[len(allowedSpansStatsIntervals)-1]) * time.Second
+
+	if gei.Interval < min || gei.Interval > max {
+		return false
+	}
+	nearest := min
+	for _, seconds := range allowedSpansStatsIntervals {
+		valid := time.Duration(seconds) * time.Second
+		if (gei.Interval - valid).Abs() < (gei.Interval - nearest).Abs() {
+			nearest = valid
+		}
+	}
+	if nearest > gei.To.Sub(gei.From) {
+		return false
+	}
+	gei.Interval = nearest
+	return true
+}
+
 type GetSpansStatsInput struct {
 	OrganizationSlug string
 	ProjectIds       []string
@@ -33,6 +56,9 @@ func (gei *GetSpansStatsInput) ToQuery() string {
 	params.Set("query", gei.Query)
 	params.Set("start", gei.From.Format("2006-01-02T15:04:05Z07:00"))
 	params.Set("end", gei.To.Format("2006-01-02T15:04:05Z07:00"))
+	if gei.snapInterval() {
+		params.Set("interval", FormatSentryInterval(gei.Interval))
+	}
 	params.Set("partial", "1")
 	params.Set("excludeOther", "0")
 	params.Set("sampling", "NORMAL")


### PR DESCRIPTION
# Summary

Spans Stats queries (`/events-stats/?dataset=spans`) were not forwarding the Grafana query interval to Sentry. As a result, Sentry always fell back to its default rollup, causing the returned time series to use bucket sizes that did not match the panel interval (for example, a panel configured with a 5-minute interval could receive hourly buckets).

# Changes

- Forward the Grafana interval (`intervalMs` → `backendQuery.Interval`) to Sentry as the `interval` query parameter using the existing `FormatSentryInterval` helper.
- Snap the requested interval to the nearest value accepted by the Sentry Spans Stats API, since the API only supports a fixed set of intervals:
  - `15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 14400, 21600, 43200, 86400` seconds.
  - Examples:
    - `32s` → `30s`
    - `119s` → `120s` (`2m`)
- Omit the `interval` parameter (allowing Sentry to use its default rollup) when:
  - the interval is below `15s`;
  - the interval is above `24h`;
  - the interval is larger than the query time range, since Sentry rejects these requests with `Interval cannot be larger than the date range`.

# Notes / Questions

I'm not a maintainer of this project, so I'd appreciate some guidance on the expected contribution workflow.

- Is this implementation the preferred approach, or would you like it handled differently?
- Since I only need this change for my own Grafana instance, would you recommend keeping it as a local patch instead of contributing it upstream, or is opening a PR like this the preferred approach?

If you'd like this implemented differently, I'm happy to update the PR based on your feedback.