### PR TITLE
fix(issues): use lifetime firstSeen/lastSeen instead of range-scoped values

### DIFF
--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -35,6 +35,8 @@ All Sentry query types are available for annotations. The **Issues** and **Event
 | Query type   | Recommended | Notes                                                                                      |
 | ------------ | ----------- | ------------------------------------------------------------------------------------------ |
 | Issues       | Yes         | Uses `FirstSeen` and `LastSeen` timestamps. Best for marking when issues appeared.         |
+
+The `FirstSeen` and `LastSeen` timestamps are the issue's whole-of-life values, matching what the Sentry UI displays. By default, annotations use the first time field in the result, so issue markers appear at `FirstSeen`, and an issue first seen before the visible time range doesn't produce a marker inside it. To mark an issue's first and last matching events within the dashboard time range instead, map the annotation **Time** field to `FirstSeenInRange` in the annotation editor, and optionally **Time end** to `LastSeenInRange` to render a range.
 | Events       | Yes         | Uses event timestamps. Useful for marking individual error or transaction events.          |
 | Spans        | Yes         | Uses span timestamps. Useful for marking specific span occurrences.                        |
 | Events Stats | No          | Returns time-series data, which is less natural for annotation markers.                    |

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -35,14 +35,14 @@ All Sentry query types are available for annotations. The **Issues** and **Event
 | Query type   | Recommended | Notes                                                                                      |
 | ------------ | ----------- | ------------------------------------------------------------------------------------------ |
 | Issues       | Yes         | Uses `FirstSeen` and `LastSeen` timestamps. Best for marking when issues appeared.         |
-
-The `FirstSeen` and `LastSeen` timestamps are the issue's whole-of-life values, matching what the Sentry UI displays. By default, annotations use the first time field in the result, so issue markers appear at `FirstSeen`, and an issue first seen before the visible time range doesn't produce a marker inside it. To mark an issue's first and last matching events within the dashboard time range instead, map the annotation **Time** field to `FirstSeenInRange` in the annotation editor, and optionally **Time end** to `LastSeenInRange` to render a range.
 | Events       | Yes         | Uses event timestamps. Useful for marking individual error or transaction events.          |
 | Spans        | Yes         | Uses span timestamps. Useful for marking specific span occurrences.                        |
 | Events Stats | No          | Returns time-series data, which is less natural for annotation markers.                    |
 | Spans Stats  | No          | Returns time-series data, which is less natural for annotation markers.                    |
 | Metrics      | No          | Returns time-series data, which is less natural for annotation markers.                    |
 | Stats        | No          | Returns time-series data, which is less natural for annotation markers.                    |
+
+For Issues queries, the `FirstSeen` and `LastSeen` timestamps are the issue's whole-of-life values, matching what the Sentry UI displays. By default, annotations use the first time field in the result, so issue markers appear at `FirstSeen`, and an issue first seen before the visible time range doesn't produce a marker inside it. To mark an issue's first and last matching events within the dashboard time range instead, map the annotation **Time** field to `FirstSeenInRange` in the annotation editor, and optionally **Time end** to `LastSeenInRange` to render a range.
 
 ## Create an annotation query
 

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -57,6 +57,16 @@ Use the Issues query type to retrieve a list of Sentry issues. Results are filte
 | **Sort By**  | (Optional) The order of results. Options: Last Seen, First Seen, Priority, Events, Users.                                                                     |
 | **Limit**    | (Optional) The maximum number of results to return. Default: `100`. Maximum: `10000`.                                                                          |
 
+#### Issue date and count fields
+
+The dashboard time range selects which issues are returned, but the returned fields differ in how they treat that range:
+
+| Field                                 | Scope                                                                                                                        |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `FirstSeen`, `LastSeen`               | The issue's whole-of-life timestamps, matching what the Sentry UI displays. These can fall outside the dashboard time range. |
+| `FirstSeenInRange`, `LastSeenInRange` | The timestamps of the issue's first and last matching events within the dashboard time range.                                |
+| `Count`, `UserCount`                  | The number of events and affected users within the dashboard time range, not the issue's lifetime totals.                    |
+
 #### Issue query examples
 
 - `is:unresolved` -- Show only unresolved issues.

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -3,8 +3,10 @@ package handlers_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/sentry-datasource/pkg/framer"
 	"github.com/grafana/sentry-datasource/pkg/plugin"
 	"github.com/grafana/sentry-datasource/pkg/util"
@@ -26,9 +28,80 @@ func TestSentryDatasource_Issues(t *testing.T) {
 		assert.Nil(t, res.Responses["A"].Error)
 		require.Equal(t, 1, len(res.Responses["A"].Frames))
 		assert.Equal(t, "Issues (A)", res.Responses["A"].Frames[0].Name)
-		require.Equal(t, 33, len(res.Responses["A"].Frames[0].Fields))
+		require.Equal(t, 35, len(res.Responses["A"].Frames[0].Fields))
 		require.Equal(t, 3, res.Responses["A"].Frames[0].Fields[0].Len())
 	})
+
+	t.Run("FirstSeen and LastSeen should use lifetime values when present", func(t *testing.T) {
+		sc := util.NewFakeClient(util.FakeDoer{Body: `[{
+			"firstSeen": "2026-07-09T00:18:03Z",
+			"lastSeen": "2026-07-10T19:35:03Z",
+			"lifetime": {
+				"count": "23620",
+				"userCount": 8,
+				"firstSeen": "2025-12-30T13:46:46.300599Z",
+				"lastSeen": "2026-07-16T03:24:23Z"
+			}
+		}]`})
+		ds := plugin.NewDatasourceInstance(sc)
+		ctx := context.TODO()
+
+		res, _ := ds.QueryData(ctx, &backend.QueryDataRequest{Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(`{
+			"queryType" : "issues"
+		}`)}}})
+
+		assert.Nil(t, res.Responses["A"].Error)
+		require.Equal(t, 1, len(res.Responses["A"].Frames))
+		frame := res.Responses["A"].Frames[0]
+		assert.Equal(t, mustParseTime(t, "2025-12-30T13:46:46.300599Z"), fieldTimeAt(t, frame, "FirstSeen", 0))
+		assert.Equal(t, mustParseTime(t, "2026-07-16T03:24:23Z"), fieldTimeAt(t, frame, "LastSeen", 0))
+		assert.Equal(t, mustParseTime(t, "2026-07-09T00:18:03Z"), fieldTimeAt(t, frame, "FirstSeenInRange", 0))
+		assert.Equal(t, mustParseTime(t, "2026-07-10T19:35:03Z"), fieldTimeAt(t, frame, "LastSeenInRange", 0))
+		for _, field := range frame.Fields {
+			assert.NotContains(t, field.Name, "Lifetime", "lifetime object should not leak into the frame as columns")
+		}
+	})
+
+	t.Run("FirstSeen and LastSeen should be kept as-is when lifetime is absent", func(t *testing.T) {
+		sc := util.NewFakeClient(util.FakeDoer{Body: `[{
+			"firstSeen": "2026-07-09T00:18:03Z",
+			"lastSeen": "2026-07-10T19:35:03Z"
+		}]`})
+		ds := plugin.NewDatasourceInstance(sc)
+		ctx := context.TODO()
+
+		res, _ := ds.QueryData(ctx, &backend.QueryDataRequest{Queries: []backend.DataQuery{{RefID: "A", JSON: []byte(`{
+			"queryType" : "issues"
+		}`)}}})
+
+		assert.Nil(t, res.Responses["A"].Error)
+		require.Equal(t, 1, len(res.Responses["A"].Frames))
+		frame := res.Responses["A"].Frames[0]
+		assert.Equal(t, mustParseTime(t, "2026-07-09T00:18:03Z"), fieldTimeAt(t, frame, "FirstSeen", 0))
+		assert.Equal(t, mustParseTime(t, "2026-07-10T19:35:03Z"), fieldTimeAt(t, frame, "LastSeen", 0))
+	})
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	require.NoError(t, err)
+	return parsed
+}
+
+func fieldTimeAt(t *testing.T, frame *data.Frame, fieldName string, rowIdx int) time.Time {
+	t.Helper()
+	for _, field := range frame.Fields {
+		if field.Name == fieldName {
+			value, ok := field.ConcreteAt(rowIdx)
+			require.True(t, ok, "field %q has no concrete value at row %d", fieldName, rowIdx)
+			parsed, ok := value.(time.Time)
+			require.True(t, ok, "field %q is not a time field", fieldName)
+			return parsed
+		}
+	}
+	t.Fatalf("field %q not found in frame", fieldName)
+	return time.Time{}
 }
 
 func TestSentryDatasource_StatsV2(t *testing.T) {

--- a/pkg/sentry/issues.go
+++ b/pkg/sentry/issues.go
@@ -49,6 +49,18 @@ type SentryIssue struct {
 	SubscriptionDetails struct {
 		Reason string `json:"reason"`
 	} `json:"subscriptionDetails"`
+	// Sentry scopes the top-level firstSeen/lastSeen/count/userCount to the
+	// requested start/end window and reports the whole-of-life values in the
+	// lifetime object, which is what Sentry's own UI displays. Excluded from
+	// the frame because its dates are copied over FirstSeen/LastSeen.
+	Lifetime struct {
+		Count     string    `json:"count"`
+		UserCount int64     `json:"userCount"`
+		FirstSeen time.Time `json:"firstSeen"`
+		LastSeen  time.Time `json:"lastSeen"`
+	} `json:"lifetime" frame:"-"`
+	FirstSeenInRange time.Time `json:"-"`
+	LastSeenInRange  time.Time `json:"-"`
 	// StatusDetails struct {
 	// } `json:"statusDetails"`
 	// Stats struct {
@@ -96,5 +108,23 @@ func (sc *SentryClient) GetIssues(gii GetIssuesInput) ([]SentryIssue, string, er
 	out := []SentryIssue{}
 	executedQueryString := gii.ToQuery()
 	err := sc.Fetch(executedQueryString, &out)
+	for i := range out {
+		out[i].applyLifetimeDates()
+	}
 	return out, sc.BaseURL + executedQueryString, err
+}
+
+// applyLifetimeDates promotes the lifetime firstSeen/lastSeen to the top-level
+// fields so they match what Sentry's own UI shows, keeping the window-scoped
+// values available under explicit names. The zero checks retain the top-level
+// values on Sentry instances that do not return a lifetime object.
+func (si *SentryIssue) applyLifetimeDates() {
+	si.FirstSeenInRange = si.FirstSeen
+	si.LastSeenInRange = si.LastSeen
+	if !si.Lifetime.FirstSeen.IsZero() {
+		si.FirstSeen = si.Lifetime.FirstSeen
+	}
+	if !si.Lifetime.LastSeen.IsZero() {
+		si.LastSeen = si.Lifetime.LastSeen
+	}
 }


### PR DESCRIPTION
Fixes #592. The same defect was previously reported in #168.

**What happened before**

The Issues query type passes the dashboard time range to Sentry's `/organizations/{org}/issues/` endpoint as `start`/`end`. When that endpoint receives a time window, the top-level `firstSeen` and `lastSeen` in its response are scoped to that window rather than reflecting the whole life of the issue. The plugin surfaced those values directly, so the `FirstSeen` and `LastSeen` columns changed whenever the dashboard time picker changed and never matched what Sentry's own UI shows.

Confirmed against the live Sentry API: for one and the same issue, a 90-day range returned `firstSeen` 2026-07-09, a 48-hour range returned 2026-07-15, while the actual first-seen date shown in Sentry's UI (carried in the API's `lifetime` object) was 2025-12-30 throughout.

**This is a deliberate, user-visible behaviour change**

The new values are the expected behaviour, not a regression. Sentry's own UI shows the lifetime dates, and both issues filed about this (#168, #592) report the window-scoped dates as wrong.

| Field | Before | After |
|---|---|---|
| `FirstSeen` | First matching event within the dashboard time range | When the issue was first seen ever, matching Sentry's UI |
| `LastSeen` | Last matching event within the dashboard time range | When the issue was last seen ever, matching Sentry's UI |
| `FirstSeenInRange` | Did not exist | First matching event within the dashboard time range (the old `FirstSeen` value) |
| `LastSeenInRange` | Did not exist | Last matching event within the dashboard time range (the old `LastSeen` value) |
| `Count`, `UserCount` | Events and users within the dashboard time range | Unchanged, still scoped to the dashboard time range |

If you relied on the old clamped dates, switch to `FirstSeenInRange` and `LastSeenInRange`.

Annotations from Issues queries default to the frame's first time field, so markers now sit at the issue's true first-seen instant and no longer appear when that falls outside the visible range. Mapping the annotation **Time** field to `FirstSeenInRange` restores the previous marker positions. This is the behaviour change #168 asked for.

On Sentry instances whose responses carry no `lifetime` object, the previous behaviour is retained unchanged.

**Verification**

- New backend tests cover the swap, the in-range columns, the fallback without `lifetime`, and that the `lifetime` object doesn't leak into the frame as columns.
- Verified live against sentry.io through the plugin in Grafana 12.4.5: `FirstSeen`/`LastSeen` are stable across 90-day, 48-hour and past-window ranges and match the Sentry UI, while the `InRange` fields track the window.
- Documentation updated: the query editor doc gains a field-scope table, and the annotations doc explains the new marker behaviour and the `InRange` mapping.
