### PR TITLE
fix: interpolate template variables for spans and spans stats queries

### DIFF
--- a/src/app/replace.spec.ts
+++ b/src/app/replace.spec.ts
@@ -1,6 +1,6 @@
 import { ScopedVars } from '@grafana/data';
 import * as runtime from '@grafana/runtime';
-import { SentryIssuesQuery, SentryEventsQuery, SentryStatsV2Query } from 'types';
+import { SentryIssuesQuery, SentryEventsQuery, SentrySpansQuery, SentrySpansStatsQuery, SentryStatsV2Query } from 'types';
 import { applyTemplateVariables, replaceProjectIDs } from './replace';
 
 describe('replace', () => {
@@ -87,6 +87,38 @@ describe('replace', () => {
       expect(output.projectIds).toStrictEqual(['bar', 'baz']);
       expect(output.environments).toStrictEqual(['bar', 'baz']);
       expect(output.eventsQuery).toStrictEqual('hello bar');
+    });
+
+    it('should interpolate template variables for spans', () => {
+      const query: SentrySpansQuery = {
+        refId: '',
+        queryType: 'spans',
+        projectIds: ['${foo}', 'baz'],
+        environments: ['${foo}', 'baz'],
+        eventsQuery: 'hello ${foo}',
+      };
+
+      const output = applyTemplateVariables(query, { foo: { value: 'bar', text: 'bar' } }) as SentrySpansQuery;
+      expect(output.projectIds).toStrictEqual(['bar', 'baz']);
+      expect(output.environments).toStrictEqual(['bar', 'baz']);
+      expect(output.eventsQuery).toStrictEqual('hello bar');
+    });
+
+    it('should interpolate template variables for spansStats', () => {
+      const query: SentrySpansStatsQuery = {
+        refId: '',
+        queryType: 'spansStats',
+        projectIds: ['${foo}', 'baz'],
+        environments: ['${foo}', 'baz'],
+        eventsStatsQuery: 'hello ${foo}',
+        eventsStatsYAxis: [],
+        eventsStatsGroups: [],
+      };
+
+      const output = applyTemplateVariables(query, { foo: { value: 'bar', text: 'bar' } }) as SentrySpansStatsQuery;
+      expect(output.projectIds).toStrictEqual(['bar', 'baz']);
+      expect(output.environments).toStrictEqual(['bar', 'baz']);
+      expect(output.eventsStatsQuery).toStrictEqual('hello bar');
     });
 
     it('should interpolate template variables for statsV2', () => {

--- a/src/app/replace.ts
+++ b/src/app/replace.ts
@@ -33,7 +33,21 @@ export const applyTemplateVariables = (query: SentryQuery, scopedVars: ScopedVar
         projectIds: interpolateVariableArray(query.projectIds, scopedVars),
         environments: interpolateVariableArray(query.environments, scopedVars),
       };
+    case 'spans':
+      return {
+        ...query,
+        eventsQuery: interpolateVariable(query.eventsQuery || '', scopedVars),
+        projectIds: interpolateVariableArray(query.projectIds, scopedVars),
+        environments: interpolateVariableArray(query.environments, scopedVars),
+      };
     case 'eventsStats':
+      return {
+        ...query,
+        eventsStatsQuery: interpolateVariable(query.eventsStatsQuery || '', scopedVars),
+        projectIds: interpolateVariableArray(query.projectIds, scopedVars),
+        environments: interpolateVariableArray(query.environments, scopedVars),
+      };
+    case 'spansStats':
       return {
         ...query,
         eventsStatsQuery: interpolateVariable(query.eventsStatsQuery || '', scopedVars),


### PR DESCRIPTION
## What

`applyTemplateVariables` had no cases for the `spans` and `spansStats` query types, so dashboard variables in Spans and Spans Stats query fields (search query, projects, environments) were sent to the backend uninterpolated. This adds the two missing cases, mirroring the events and eventsStats handling, with jest coverage.

## User-facing impact

Template variables such as `${project}` or `$environment` now resolve in Spans and Spans Stats queries. Previously the raw variable text was sent to Sentry, returning empty or incorrect results. The bug has shipped since spans support landed in #517 (v2.2.x).

## Notes

The same fix is temporarily duplicated on #725 so that branch works standalone. Whichever merges second will see a trivial conflict in the same switch, resolved by keeping one copy of the cases.